### PR TITLE
feat: aggregate rbac permissions

### DIFF
--- a/helm-charts/secrets-operator/templates/user-rbac.yaml
+++ b/helm-charts/secrets-operator/templates/user-rbac.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.enableUserRBAC }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "secrets-operator.fullname" . }}-user-admin
+  labels:
+    {{- include "secrets-operator.labels" . | nindent 4 }}
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+- apiGroups: ["secrets.infisical.com"]
+  resources: ["infisicalsecrets", "infisicalpushsecrets", "infisicaldynamicsecrets", "clustergenerators"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"]
+- apiGroups: ["secrets.infisical.com"]
+  resources: ["infisicalsecrets/status", "infisicalpushsecrets/status", "infisicaldynamicsecrets/status"]
+  verbs: ["get", "list", "watch"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "secrets-operator.fullname" . }}-user-view
+  labels:
+    {{- include "secrets-operator.labels" . | nindent 4 }}
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
+rules:
+- apiGroups: ["secrets.infisical.com"]
+  resources: ["infisicalsecrets", "infisicalpushsecrets", "infisicaldynamicsecrets", "clustergenerators"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["secrets.infisical.com"]
+  resources: ["infisicalsecrets/status", "infisicalpushsecrets/status", "infisicaldynamicsecrets/status"]
+  verbs: ["get", "list", "watch"]
+{{- end }}

--- a/scripts/generate-helm.sh
+++ b/scripts/generate-helm.sh
@@ -82,6 +82,11 @@ for rbac_file in "${HELM_DIR}/templates"/*-rbac.yaml; do
       continue
     fi
 
+    if [[ "$(basename "$rbac_file")" == "user-rbac.yaml" ]]; then
+      echo "Skipping user-rbac.yaml"
+      continue
+    fi
+
     if [[ "$(basename "$rbac_file")" == "leader-election-rbac.yaml" ]]; then
       echo "Skipping infisicaldynamicsecret-admin-rbac.yaml"
       continue


### PR DESCRIPTION
Kubernetes supports "cluster role aggregation" which allows inserting custom policy rules into default cluster roles like admin, edit, and view. This integrates new resources into the cluster's RBAC policy as if they were built-in resources. 

Currently users installing the operator on OpenShift with least-privilege will run into issues with their admin / editor roles because they don't have full access to everything.

This fix will insert infisical-specific RBAC rules into the clusters default admin / editor roles.

Read more: https://kubernetes.io/docs/reference/access-authn-authz/rbac/#aggregated-clusterroles