### PR TITLE
misc: updated chart testing to have minimal permission

### DIFF
--- a/.github/workflows/run-helm-chart-tests-secret-operator.yml
+++ b/.github/workflows/run-helm-chart-tests-secret-operator.yml
@@ -1,38 +1,63 @@
 name: Run Helm Chart Tests for Secret Operator
 on:
-    pull_request:
-        paths:
-            - "helm-charts/secrets-operator/**"
-            - ".github/workflows/run-helm-chart-tests-secret-operator.yml"
+  pull_request:
+    paths:
+      - "helm-charts/secrets-operator/**"
+      - ".github/workflows/run-helm-chart-tests-secret-operator.yml"
 
 jobs:
-    test-helm:
-        name: Test Helm Chart
-        runs-on: ubuntu-latest
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v3
-              with:
-                  fetch-depth: 0
+  test-helm:
+    name: Test Helm Chart
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
-            - name: Set up Helm
-              uses: azure/setup-helm@v4.2.0
-              with:
-                  version: v3.17.0
+      - name: Set up Helm
+        uses: azure/setup-helm@v4.2.0
+        with:
+          version: v3.17.0
 
-            - uses: actions/setup-python@v5.3.0
-              with:
-                  python-version: "3.x"
-                  check-latest: true
+      - uses: actions/setup-python@v5.3.0
+        with:
+          python-version: "3.x"
+          check-latest: true
 
-            - name: Set up chart-testing
-              uses: helm/chart-testing-action@v2.7.0
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.7.0
 
-            - name: Run chart-testing (lint)
-              run: ct lint --config ct.yaml --charts helm-charts/secrets-operator
+      - name: Run chart-testing (lint)
+        run: ct lint --config ct.yaml --charts helm-charts/secrets-operator
 
-            - name: Create kind cluster
-              uses: helm/kind-action@v1.12.0
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.12.0
 
-            - name: Run chart-testing (install)
-              run: ct install --config ct.yaml --charts helm-charts/secrets-operator
+      - name: Install CRDs first
+        run: |
+          echo "Installing CRDs before testing with minimal permissions..."
+          kubectl apply -f config/crd/bases/
+
+      - name: Setup minimal RBAC user for testing
+        run: |
+          echo "Creating minimal RBAC user for chart testing..."
+
+          # Create a service account for minimal testing
+          kubectl create serviceaccount minimal-test-user -n kube-system
+
+          # Apply the existing minimal-rbac.yaml file
+          kubectl apply -f helm-charts/secrets-operator/ci/minimal-rbac.yaml
+
+          # Get the service account token and create a kubeconfig for the minimal user
+          TOKEN=$(kubectl create token minimal-test-user -n kube-system --duration=1h)
+
+          # Create a new kubeconfig context for the minimal user
+          kubectl config set-credentials minimal-test-user --token=$TOKEN
+          kubectl config set-context minimal-test-context --cluster=kind-kind --user=minimal-test-user
+
+          # Switch to the minimal user context
+          kubectl config use-context minimal-test-context
+
+      - name: Run chart-testing (install) with minimal permissions
+        run: ct install --config ct.yaml --charts helm-charts/secrets-operator

--- a/helm-charts/secrets-operator/ci/ci-values.yaml
+++ b/helm-charts/secrets-operator/ci/ci-values.yaml
@@ -1,0 +1,3 @@
+# Values file for chart testing
+# CRDs are installed separately in the CI workflow
+installCRDs: false

--- a/helm-charts/secrets-operator/ci/minimal-rbac.yaml
+++ b/helm-charts/secrets-operator/ci/minimal-rbac.yaml
@@ -1,0 +1,212 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: minimal-operator-permissions
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - secrets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - ""
+    resources:
+      - pods/log
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts/token
+    verbs:
+      - create
+  - apiGroups:
+      - apps
+    resources:
+      - daemonsets
+      - deployments
+      - statefulsets
+      - replicasets
+    verbs:
+      - get
+      - list
+      - update
+      - watch
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+  - apiGroups:
+      - secrets.infisical.com
+    resources:
+      - clustergenerators
+      - infisicaldynamicsecrets
+      - infisicalpushsecrets
+      - infisicalsecrets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - secrets.infisical.com
+    resources:
+      - infisicaldynamicsecrets/finalizers
+      - infisicalpushsecrets/finalizers
+      - infisicalsecrets/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - secrets.infisical.com
+    resources:
+      - infisicaldynamicsecrets/status
+      - infisicalpushsecrets/status
+      - infisicalsecrets/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - list
+      - create
+      - delete
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - roles
+      - rolebindings
+      - clusterroles
+      - clusterrolebindings
+    verbs:
+      - get
+      - list
+      - create
+      - delete
+      - update
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+      - update
+      - patch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - create
+      - delete
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+      - list
+      - create
+      - delete
+      - update
+      - patch
+  - nonResourceURLs:
+      - /metrics
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: minimal-operator-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: minimal-operator-permissions
+subjects:
+  - kind: ServiceAccount
+    name: minimal-test-user
+    namespace: kube-system


### PR DESCRIPTION
This PR updates our chart testing pipeline to execute with a Kubernetes user with minimal permission so that we can quickly detect when a breaking RBAC change is introduced