### PR TITLE
fix: sprig templating

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -41,6 +41,7 @@ import (
 
 	secretsv1alpha1 "github.com/Infisical/infisical/k8-operator/api/v1alpha1"
 	"github.com/Infisical/infisical/k8-operator/internal/controller"
+	"github.com/Infisical/infisical/k8-operator/internal/template"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -219,6 +220,8 @@ func main() {
 		setupLog.Error(err, "unable to start manager")
 		os.Exit(1)
 	}
+
+	template.InitializeTemplateFunctions()
 
 	if err := (&controller.InfisicalSecretReconciler{
 		Client:            mgr.GetClient(),


### PR DESCRIPTION
Re-added sprig templating that was accidentally overwritten during the kubebuilder v4 upgrade: https://github.com/Infisical/infisical/pull/4234/files#diff-e79353e59411de26209bf5e8bfa5136341d41372e089bd8f5ff9c6978719bd50L90