### PR TITLE
Ability to set custom deployment and service account names

### DIFF
--- a/helm-charts/secrets-operator/templates/_helpers.tpl
+++ b/helm-charts/secrets-operator/templates/_helpers.tpl
@@ -7,18 +7,18 @@ Expand the name of the chart.
 
 {{/*
 Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+We truncate at 33 chars to allow for the added role suffixes and stay within the 63 chars DNS limit.
 If release name contains chart name it will be used as a full name.
 */}}
 {{- define "secrets-operator.fullname" -}}
 {{- if .Values.fullnameOverride }}
-{{- .Values.fullnameOverride | trunc 15 | trimSuffix "-" }}
+{{- .Values.fullnameOverride | trunc 33 | trimSuffix "-" }}
 {{- else }}
 {{- $name := default .Chart.Name .Values.nameOverride }}
 {{- if contains $name .Release.Name }}
-{{- .Release.Name | trunc 15 | trimSuffix "-" }}
+{{- .Release.Name | trunc 33 | trimSuffix "-" }}
 {{- else }}
-{{- printf "%s-%s" .Release.Name $name | trunc 15 | trimSuffix "-" }}
+{{- printf "%s-%s" .Release.Name $name | trunc 33 | trimSuffix "-" }}
 {{- end }}
 {{- end }}
 {{- end }}
@@ -54,9 +54,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create the name of the service account to use
 */}}
 {{- define "secrets-operator.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
-{{- default (include "secrets-operator.fullname" .) .Values.serviceAccount.name }}
+{{- if .Values.controllerManager.serviceAccount.create }}
+{{- default (include "secrets-operator.fullname" .) .Values.controllerManager.serviceAccount.name }}
 {{- else }}
-{{- default "default" .Values.serviceAccount.name }}
+{{- default "default" .Values.controllerManager.serviceAccount.name }}
 {{- end }}
 {{- end }}

--- a/helm-charts/secrets-operator/templates/deployment.yaml
+++ b/helm-charts/secrets-operator/templates/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "secrets-operator.fullname" . }}-controller-manager
+  name: {{ include "secrets-operator.fullname" . }}
   labels:
     control-plane: controller-manager
   {{- include "secrets-operator.labels" . | nindent 4 }}
@@ -51,7 +51,7 @@ spec:
           | nindent 10 }}
       securityContext:
         runAsNonRoot: true
-      serviceAccountName: {{ include "secrets-operator.fullname" . }}-controller-manager
+      serviceAccountName: {{ include "secrets-operator.serviceAccountName" . }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/helm-charts/secrets-operator/templates/leader-election-rbac.yaml
+++ b/helm-charts/secrets-operator/templates/leader-election-rbac.yaml
@@ -49,5 +49,5 @@ roleRef:
   name: '{{ include "secrets-operator.fullname" . }}-leader-election-role'
 subjects:
 - kind: ServiceAccount
-  name: '{{ include "secrets-operator.fullname" . }}-controller-manager'
+  name: {{ include "secrets-operator.serviceAccountName" . }}
   namespace: '{{ .Release.Namespace }}'

--- a/helm-charts/secrets-operator/templates/manager-rbac.yaml
+++ b/helm-charts/secrets-operator/templates/manager-rbac.yaml
@@ -120,5 +120,5 @@ roleRef:
   name: '{{ include "secrets-operator.fullname" . }}-manager-role'
 subjects:
 - kind: ServiceAccount
-  name: '{{ include "secrets-operator.fullname" . }}-controller-manager'
+  name: {{ include "secrets-operator.serviceAccountName" . }}
   namespace: '{{ .Release.Namespace }}'

--- a/helm-charts/secrets-operator/templates/metrics-auth-rbac.yaml
+++ b/helm-charts/secrets-operator/templates/metrics-auth-rbac.yaml
@@ -49,5 +49,5 @@ roleRef:
   name: '{{ include "secrets-operator.fullname" . }}-metrics-auth-role'
 subjects:
 - kind: ServiceAccount
-  name: '{{ include "secrets-operator.fullname" . }}-controller-manager'
+  name: {{ include "secrets-operator.serviceAccountName" . }}
   namespace: '{{ .Release.Namespace }}'

--- a/helm-charts/secrets-operator/templates/metrics-service.yaml
+++ b/helm-charts/secrets-operator/templates/metrics-service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "secrets-operator.fullname" . }}-controller-manager-metrics-service
+  name: {{ include "secrets-operator.fullname" . }}-metrics-service
   labels:
     control-plane: controller-manager
   {{- include "secrets-operator.labels" . | nindent 4 }}

--- a/helm-charts/secrets-operator/templates/serviceaccount.yaml
+++ b/helm-charts/secrets-operator/templates/serviceaccount.yaml
@@ -1,8 +1,10 @@
+{{- if .Values.controllerManager.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "secrets-operator.fullname" . }}-controller-manager
+  name: {{ include "secrets-operator.serviceAccountName" . }}
   labels:
   {{- include "secrets-operator.labels" . | nindent 4 }}
   annotations:
     {{- toYaml .Values.controllerManager.serviceAccount.annotations | nindent 4 }}
+{{- end }}

--- a/helm-charts/secrets-operator/values.yaml
+++ b/helm-charts/secrets-operator/values.yaml
@@ -24,6 +24,8 @@ controllerManager:
       type: RuntimeDefault
   replicas: 1
   serviceAccount:
+    create: true
+    name: ""
     annotations: {}
   nodeSelector: {}
   tolerations: []


### PR DESCRIPTION
The chart currently lacks this standard functionality. The user-provided name gets truncated at 15 characters and a long suffix is added to the result. A release name of `infisical-operator`, for example, results in a deployment and service account named `infisical-opera-controller-manager`. The service account appears to be an oversight since the helper function already exists but is not being used in the templates. This PR:

- Removes all occurences of the `-controller-manager` suffix. This allows for a custom deployment name without harcoded parts, and of up to 33 characters instead of 15.
- Enables the helper function wherever the service account is currently harcoded. Crucially, this also allows us to disable service account creation completely and use an existing one managed by IaC.