### PR TITLE
fix: fixed Python version in GitHub Actions workflow to 3.13

### DIFF
--- a/.github/workflows/release-k8-operator-helm.yml
+++ b/.github/workflows/release-k8-operator-helm.yml
@@ -19,7 +19,7 @@ jobs:
 
             - uses: actions/setup-python@v5.3.0
               with:
-                  python-version: "3.x"
+                  python-version: "3.13"
                   check-latest: true
 
             - name: Set up chart-testing


### PR DESCRIPTION
Fixed to 3.13 because 3.14 doesn't work with Yamale dependency for chart-testing.

https://github.com/23andMe/Yamale/releases
