### PR TITLE
Update reconciler.go

### DIFF
--- a/internal/services/infisicalsecret/reconciler.go
+++ b/internal/services/infisicalsecret/reconciler.go
@@ -693,7 +693,6 @@ func (r *InfisicalSecretReconciler) ReconcileInfisicalSecret(ctx context.Context
 
 	resourceVariables := r.getResourceVariables(*infisicalSecret, resourceVariablesMap)
 	infisicalClient := resourceVariables.InfisicalClient
-	cancelCtx := resourceVariables.CancelCtx
 	authDetails := resourceVariables.AuthDetails
 	var err error
 
@@ -710,14 +709,9 @@ func (r *InfisicalSecretReconciler) ReconcileInfisicalSecret(ctx context.Context
 			return 0, fmt.Errorf("unable to authenticate [err=%s]", err)
 		}
 
-		r.updateResourceVariables(*infisicalSecret, util.ResourceVariables{
-			InfisicalClient:  infisicalClient,
-			CancelCtx:        cancelCtx,
-			AuthDetails:      authDetails,
-			ServerSentEvents: resourceVariables.ServerSentEvents, // Preserve existing SSE registry
-			ServerETag:       resourceVariables.ServerETag,       // Preserve ETag across re-auth
-			LastSecretsCount: resourceVariables.LastSecretsCount, // Preserve count across re-auth
-		}, resourceVariablesMap)
+		// Update the local resourceVariables so that the auth details are preserved when resourceVariables is written back to the map later in this function.
+		resourceVariables.AuthDetails = authDetails
+		r.updateResourceVariables(*infisicalSecret, resourceVariables, resourceVariablesMap)
 	}
 
 	previousETag := resourceVariables.ServerETag


### PR DESCRIPTION
This writes the local `resourceVariables` back to the map on every reconcile.

In the old code, the auth block built a new struct and wrote it to the map, but never touched the local resourceVariables. So resourceVariables.AuthDetails stayed empty. Then line 813 wrote that empty local copy back to the map, overwriting the good data.

In the new code, `resourceVariables.AuthDetails = authDetails` updates the local variable itself. So when line 813 writes resourceVariables back to the map later, it still has the correct auth details.

The fix is making sure the local variable carries the correct auth details so it does not get wiped when the same local variable is written to the map again at the end of the function. This would only happen when `NotModified` was `false` because when it is `true`, the function returns early before reaching the overwrite at the end. That early return means the correct auth details in the map are left untouched. But when `NotModified` is `false` (secrets changed) , the function runs all the way to the end and the overwrite fires, wiping the auth details every cycle.

ETags appear to have issues in EU Cloud, making `NotModified` false on every run, indicating that secrets have changed on every run