### PR TITLE
fix: hash rendered output for managed-secret version annotation (ENG-5058)

### DIFF
--- a/internal/crypto/crypto.go
+++ b/internal/crypto/crypto.go
@@ -1,10 +1,12 @@
 package crypto
 
 import (
+	"bytes"
 	"crypto/aes"
 	"crypto/cipher"
 	"fmt"
 	"hash/crc32"
+	"sort"
 
 	"golang.org/x/crypto/nacl/box"
 )
@@ -39,4 +41,24 @@ func DecryptAsymmetric(ciphertext []byte, nonce []byte, publicKey []byte, privat
 func ComputeEtag(data []byte) string {
 	crc := crc32.ChecksumIEEE(data)
 	return fmt.Sprintf(`W/"secrets-%d-%08X"`, len(data), crc)
+}
+
+// ComputeRenderedEtag hashes the post-template bytes that land in a managed
+// Secret/ConfigMap. Keys are sorted so iteration order doesn't perturb the hash;
+// each key/value is null-separated to prevent boundary collisions.
+func ComputeRenderedEtag(rendered map[string][]byte) string {
+	keys := make([]string, 0, len(rendered))
+	for k := range rendered {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var buf bytes.Buffer
+	for _, k := range keys {
+		buf.WriteString(k)
+		buf.WriteByte(0)
+		buf.Write(rendered[k])
+		buf.WriteByte(0)
+	}
+	return ComputeEtag(buf.Bytes())
 }

--- a/internal/crypto/crypto_test.go
+++ b/internal/crypto/crypto_test.go
@@ -1,0 +1,44 @@
+package crypto
+
+import "testing"
+
+func TestComputeRenderedEtag_StableAcrossMapOrder(t *testing.T) {
+	a := map[string][]byte{
+		"alpha": []byte("1"),
+		"beta":  []byte("2"),
+		"gamma": []byte("3"),
+	}
+	b := map[string][]byte{
+		"gamma": []byte("3"),
+		"alpha": []byte("1"),
+		"beta":  []byte("2"),
+	}
+	for i := 0; i < 50; i++ {
+		if ComputeRenderedEtag(a) != ComputeRenderedEtag(b) {
+			t.Fatalf("ComputeRenderedEtag must be insensitive to map iteration order")
+		}
+	}
+}
+
+func TestComputeRenderedEtag_DistinguishesContent(t *testing.T) {
+	base := map[string][]byte{"k": []byte("v")}
+	cases := []map[string][]byte{
+		{"k": []byte("v2")},                  // value differs
+		{"K": []byte("v")},                   // key differs
+		{"k": []byte("v"), "k2": []byte("")}, // extra empty entry
+	}
+	baseEtag := ComputeRenderedEtag(base)
+	for i, c := range cases {
+		if ComputeRenderedEtag(c) == baseEtag {
+			t.Fatalf("case %d collided with base", i)
+		}
+	}
+}
+
+func TestComputeRenderedEtag_KeyValueBoundary(t *testing.T) {
+	// Without a delimiter, "ab"+"c" and "a"+"bc" would hash the same.
+	if ComputeRenderedEtag(map[string][]byte{"ab": []byte("c")}) ==
+		ComputeRenderedEtag(map[string][]byte{"a": []byte("bc")}) {
+		t.Fatal("key/value boundary collision")
+	}
+}

--- a/internal/services/infisicalsecret/reconciler.go
+++ b/internal/services/infisicalsecret/reconciler.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"net/http"
 	"sort"
 	"strings"
@@ -119,7 +120,7 @@ func convertBinaryToStringMap(binaryMap map[string][]byte) map[string]string {
 	return stringMap
 }
 
-func (r *InfisicalSecretReconciler) createInfisicalManagedKubeResource(ctx context.Context, logger logr.Logger, infisicalSecret v1alpha1.InfisicalSecret, managedSecretReferenceInterface interface{}, secretsFromAPI []model.SingleEnvironmentVariable, ETag string, resourceType constants.ManagedKubeResourceType) error {
+func (r *InfisicalSecretReconciler) createInfisicalManagedKubeResource(ctx context.Context, logger logr.Logger, infisicalSecret v1alpha1.InfisicalSecret, managedSecretReferenceInterface interface{}, secretsFromAPI []model.SingleEnvironmentVariable, resourceType constants.ManagedKubeResourceType) error {
 	plainProcessedSecrets := make(map[string][]byte)
 
 	var managedTemplateData *v1alpha1.SecretTemplate
@@ -216,7 +217,7 @@ func (r *InfisicalSecretReconciler) createInfisicalManagedKubeResource(ctx conte
 
 		managedSecretReference := managedSecretReferenceInterface.(v1alpha1.ManagedKubeSecretConfig)
 
-		annotations[constants.SECRET_VERSION_ANNOTATION] = ETag
+		annotations[constants.SECRET_VERSION_ANNOTATION] = crypto.ComputeRenderedEtag(plainProcessedSecrets)
 		// create a new secret as specified by the managed secret spec of CRD
 		newKubeSecretInstance := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
@@ -406,7 +407,7 @@ func (r *InfisicalSecretReconciler) syncLabelsAndAnnotations(infisicalSecret v1a
 	return newAnnotations, newLabels
 }
 
-func (r *InfisicalSecretReconciler) updateInfisicalManagedKubeSecret(ctx context.Context, logger logr.Logger, infisicalSecret v1alpha1.InfisicalSecret, managedSecretReference v1alpha1.ManagedKubeSecretConfig, managedKubeSecret corev1.Secret, secretsFromAPI []model.SingleEnvironmentVariable, ETag string) error {
+func (r *InfisicalSecretReconciler) updateInfisicalManagedKubeSecret(ctx context.Context, logger logr.Logger, infisicalSecret v1alpha1.InfisicalSecret, managedSecretReference v1alpha1.ManagedKubeSecretConfig, managedKubeSecret corev1.Secret, secretsFromAPI []model.SingleEnvironmentVariable) error {
 	managedTemplateData := managedSecretReference.Template
 
 	plainProcessedSecrets := make(map[string][]byte)
@@ -446,11 +447,23 @@ func (r *InfisicalSecretReconciler) updateInfisicalManagedKubeSecret(ctx context
 		templateMetadata = managedTemplateData.Metadata
 	}
 	newAnnotations, newLabels := r.syncLabelsAndAnnotations(infisicalSecret, managedKubeSecret.ObjectMeta.Annotations, managedKubeSecret.ObjectMeta.Labels, templateMetadata)
+	newAnnotations[constants.SECRET_VERSION_ANNOTATION] = crypto.ComputeRenderedEtag(plainProcessedSecrets)
+
+	// Skip the apiserver write when the rendered output and metadata are unchanged. Without
+	// this, a sibling-secret change in the same Infisical scope flips the server-side ETag,
+	// which lands here as a 200, and an unconditional Update would bump the managed Secret's
+	// resourceVersion and trigger auto-reload restarts on Deployments that don't actually
+	// consume the changed key. See ENG-5058.
+	if maps.EqualFunc(managedKubeSecret.Data, plainProcessedSecrets, bytes.Equal) &&
+		maps.Equal(managedKubeSecret.ObjectMeta.Annotations, newAnnotations) &&
+		maps.Equal(managedKubeSecret.ObjectMeta.Labels, newLabels) {
+		logger.Info("Managed Kubernetes secret already up to date, skipping update")
+		return nil
+	}
 
 	managedKubeSecret.ObjectMeta.Labels = newLabels
 	managedKubeSecret.ObjectMeta.Annotations = newAnnotations
 	managedKubeSecret.Data = plainProcessedSecrets
-	managedKubeSecret.ObjectMeta.Annotations[constants.SECRET_VERSION_ANNOTATION] = ETag
 
 	err := r.Client.Update(ctx, &managedKubeSecret)
 	if err != nil {
@@ -461,7 +474,7 @@ func (r *InfisicalSecretReconciler) updateInfisicalManagedKubeSecret(ctx context
 	return nil
 }
 
-func (r *InfisicalSecretReconciler) updateInfisicalManagedConfigMap(ctx context.Context, logger logr.Logger, infisicalSecret v1alpha1.InfisicalSecret, managedConfigMapReference v1alpha1.ManagedKubeConfigMapConfig, managedConfigMap corev1.ConfigMap, secretsFromAPI []model.SingleEnvironmentVariable, ETag string) error {
+func (r *InfisicalSecretReconciler) updateInfisicalManagedConfigMap(ctx context.Context, logger logr.Logger, infisicalSecret v1alpha1.InfisicalSecret, managedConfigMapReference v1alpha1.ManagedKubeConfigMapConfig, managedConfigMap corev1.ConfigMap, secretsFromAPI []model.SingleEnvironmentVariable) error {
 	managedTemplateData := managedConfigMapReference.Template
 
 	plainProcessedSecrets := make(map[string][]byte)
@@ -501,11 +514,21 @@ func (r *InfisicalSecretReconciler) updateInfisicalManagedConfigMap(ctx context.
 		templateMetadata = managedTemplateData.Metadata
 	}
 	newAnnotations, newLabels := r.syncLabelsAndAnnotations(infisicalSecret, managedConfigMap.ObjectMeta.Annotations, managedConfigMap.ObjectMeta.Labels, templateMetadata)
+	newAnnotations[constants.SECRET_VERSION_ANNOTATION] = crypto.ComputeRenderedEtag(plainProcessedSecrets)
+
+	newData := convertBinaryToStringMap(plainProcessedSecrets)
+
+	// See ENG-5058 / updateInfisicalManagedKubeSecret for rationale.
+	if maps.Equal(managedConfigMap.Data, newData) &&
+		maps.Equal(managedConfigMap.ObjectMeta.Annotations, newAnnotations) &&
+		maps.Equal(managedConfigMap.ObjectMeta.Labels, newLabels) {
+		logger.Info("Managed Kubernetes config map already up to date, skipping update")
+		return nil
+	}
 
 	managedConfigMap.ObjectMeta.Labels = newLabels
 	managedConfigMap.ObjectMeta.Annotations = newAnnotations
-	managedConfigMap.Data = convertBinaryToStringMap(plainProcessedSecrets)
-	managedConfigMap.ObjectMeta.Annotations[constants.SECRET_VERSION_ANNOTATION] = ETag
+	managedConfigMap.Data = newData
 
 	err := r.Client.Update(ctx, &managedConfigMap)
 	if err != nil {
@@ -749,13 +772,12 @@ func (r *InfisicalSecretReconciler) ReconcileInfisicalSecret(ctx context.Context
 				return 0, fmt.Errorf("something went wrong when fetching the managed Kubernetes secret [%w]", err)
 			}
 
-			newEtag := crypto.ComputeEtag([]byte(fmt.Sprintf("%v", plainTextSecretsFromApi)))
 			if managedKubeSecret == nil {
-				if err := r.createInfisicalManagedKubeResource(ctx, logger, *infisicalSecret, managedSecretReference, plainTextSecretsFromApi, newEtag, constants.MANAGED_KUBE_RESOURCE_TYPE_SECRET); err != nil {
+				if err := r.createInfisicalManagedKubeResource(ctx, logger, *infisicalSecret, managedSecretReference, plainTextSecretsFromApi, constants.MANAGED_KUBE_RESOURCE_TYPE_SECRET); err != nil {
 					return 0, fmt.Errorf("failed to create managed secret [err=%s]", err)
 				}
 			} else {
-				if err := r.updateInfisicalManagedKubeSecret(ctx, logger, *infisicalSecret, managedSecretReference, *managedKubeSecret, plainTextSecretsFromApi, newEtag); err != nil {
+				if err := r.updateInfisicalManagedKubeSecret(ctx, logger, *infisicalSecret, managedSecretReference, *managedKubeSecret, plainTextSecretsFromApi); err != nil {
 					return 0, fmt.Errorf("failed to update managed secret [err=%s]", err)
 				}
 			}
@@ -783,13 +805,12 @@ func (r *InfisicalSecretReconciler) ReconcileInfisicalSecret(ctx context.Context
 				return 0, fmt.Errorf("something went wrong when fetching the managed Kubernetes config map [%w]", err)
 			}
 
-			newEtag := crypto.ComputeEtag([]byte(fmt.Sprintf("%v", plainTextSecretsFromApi)))
 			if managedKubeConfigMap == nil {
-				if err := r.createInfisicalManagedKubeResource(ctx, logger, *infisicalSecret, managedConfigMapReference, plainTextSecretsFromApi, newEtag, constants.MANAGED_KUBE_RESOURCE_TYPE_CONFIG_MAP); err != nil {
+				if err := r.createInfisicalManagedKubeResource(ctx, logger, *infisicalSecret, managedConfigMapReference, plainTextSecretsFromApi, constants.MANAGED_KUBE_RESOURCE_TYPE_CONFIG_MAP); err != nil {
 					return 0, fmt.Errorf("failed to create managed config map [err=%s]", err)
 				}
 			} else {
-				if err := r.updateInfisicalManagedConfigMap(ctx, logger, *infisicalSecret, managedConfigMapReference, *managedKubeConfigMap, plainTextSecretsFromApi, newEtag); err != nil {
+				if err := r.updateInfisicalManagedConfigMap(ctx, logger, *infisicalSecret, managedConfigMapReference, *managedKubeConfigMap, plainTextSecretsFromApi); err != nil {
 					return 0, fmt.Errorf("failed to update managed config map [err=%s]", err)
 				}
 			}

--- a/internal/services/infisicalsecret/reconciler.go
+++ b/internal/services/infisicalsecret/reconciler.go
@@ -518,7 +518,6 @@ func (r *InfisicalSecretReconciler) updateInfisicalManagedConfigMap(ctx context.
 
 	newData := convertBinaryToStringMap(plainProcessedSecrets)
 
-	// See ENG-5058 / updateInfisicalManagedKubeSecret for rationale.
 	if maps.Equal(managedConfigMap.Data, newData) &&
 		maps.Equal(managedConfigMap.ObjectMeta.Annotations, newAnnotations) &&
 		maps.Equal(managedConfigMap.ObjectMeta.Labels, newLabels) {


### PR DESCRIPTION
## Context
- Linear: [ENG-5058](https://linear.app/infisical/issue/ENG-5058/operator-etag-changes-trigger-broad-auto-reload-restarts)
- The managed Secret/ConfigMap `secrets.infisical.com/version` annotation was hashed from the full server payload (`plainTextSecretsFromApi`), so any sibling secret change in a shared Infisical scope flipped the annotation for every `InfisicalSecret` CR pointing at that scope.
- That caused `auto-reload` Deployments to roll restart simultaneously across the customer's fleet, even when the key they consume wasn't the one that changed.

## Change
- Compute the version annotation from the post-template `plainProcessedSecrets` (the bytes that actually land in `Secret.Data` / `ConfigMap.Data`) via a new `crypto.ComputeRenderedEtag`. Sorted keys + null-byte separators keep the hash deterministic across map iteration order.
- Skip the apiserver `Update()` entirely when the rendered data, annotations, and labels are all unchanged — prevents `resourceVersion` bumps that trigger spurious rollouts.
- Drop the broken `crypto.ComputeEtag([]byte(fmt.Sprintf("%v", plainTextSecretsFromApi)))` callsites and the `ETag` parameter on the create/update helpers.
- Server is unchanged; the conditional-GET / `If-None-Match` 304 fast path remains intact.

## Verify
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/crypto/...` — added `crypto_test.go` covering map-order stability, content sensitivity, and key/value boundary collisions
- [x] `go test ./internal/services/infisicalsecret/...` passes (existing suite)
- [ ] In a test cluster: create two `InfisicalSecret` CRs sharing a scope, change a sibling secret outside the templates, confirm neither managed Secret's `resourceVersion` bumps and no Deployment rolls
- [ ] In a test cluster: change a key the templates DO consume, confirm the managed Secret rolls as expected
- [ ] Note for release: existing managed Secrets in the field have an annotation under the old hash; first reconcile after upgrade will roll Deployments once as the annotation moves to the new value