### PR TITLE
chore: pin all actions to the versions they were using already

### DIFF
--- a/.github/workflows/release-k8-operator-helm.yml
+++ b/.github/workflows/release-k8-operator-helm.yml
@@ -8,22 +8,22 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0 Aug 24, 2023
               with:
                   fetch-depth: 0
 
             - name: Set up Helm
-              uses: azure/setup-helm@v4.2.0
+              uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814 # v4.2.0 Apr 15, 2024
               with:
                   version: v3.17.0
 
-            - uses: actions/setup-python@v5.3.0
+            - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0 Oct 24, 2024
               with:
                   python-version: "3.x"
                   check-latest: true
 
             - name: Set up chart-testing
-              uses: helm/chart-testing-action@v2.7.0
+              uses: helm/chart-testing-action@0d28d3144d3a25ea2cc349d6e59901c4ff469b3b # v2.7.0 Jan 20, 2025
               with:
                 yamale_version: "6.0.0"
 
@@ -42,10 +42,10 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v2
+              uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0 Mar 24, 2023
 
             - name: Install Helm
-              uses: azure/setup-helm@v3
+              uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3.5 Dec 12, 2022
               with:
                   version: v3.10.0
 

--- a/.github/workflows/release-k8-operator-helm.yml
+++ b/.github/workflows/release-k8-operator-helm.yml
@@ -31,7 +31,7 @@ jobs:
               run: ct lint --config ct.yaml --charts helm-charts/secrets-operator
 
             - name: Create kind cluster
-              uses: helm/kind-action@v1.12.0
+              uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0 Dec 23, 2024
 
             - name: Run chart-testing (install)
               run: ct install --config ct.yaml --charts helm-charts/secrets-operator

--- a/.github/workflows/release_docker_k8_operator.yaml
+++ b/.github/workflows/release_docker_k8_operator.yaml
@@ -20,17 +20,17 @@ jobs:
               run: echo "::set-output name=version::${GITHUB_REF_NAME#infisical-k8-operator/}"
 
             - name: Checkout code
-              uses: actions/checkout@v2
+              uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0 Mar 24, 2023
 
             # Dependency for helm generation
             - name: Install Helm
-              uses: azure/setup-helm@v3
+              uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3.5 Dec 12, 2022
               with:
                   version: v3.10.0
 
             # Dependency for helm generation
             - name: Install Go
-              uses: actions/setup-go@v4
+              uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4.3.0 Dec 15, 2015
               with:
                   go-version: 1.21
 
@@ -60,7 +60,7 @@ jobs:
 
             - name: Create Helm Chart PR
               id: create-pr
-              uses: peter-evans/create-pull-request@v5
+              uses: peter-evans/create-pull-request@4e1beaa7521e8b457b572c090b25bd3db56bf1c5 # v5.0.3 Mar 20, 2024
               with:
                   token: ${{ secrets.GITHUB_TOKEN }}
                   commit-message: "Update Helm chart to version ${{ steps.extract_version.outputs.version }}"
@@ -79,20 +79,20 @@ jobs:
                   base: main
 
             - name: 🔧 Set up QEMU
-              uses: docker/setup-qemu-action@v1
+              uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480 # v1.2.0 May 26, 2022
 
             - name: 🔧 Set up Docker Buildx
-              uses: docker/setup-buildx-action@v1
+              uses: docker/setup-buildx-action@f211e3e9ded2d9377c8cadc4489a4e38014bc4c9 # v1.7.0 Apr 28, 2022
 
             - name: 🐋 Login to Docker Hub
-              uses: docker/login-action@v1
+              uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7 # v1.14.1 Mar 1, 2022
               with:
                   username: ${{ secrets.DOCKERHUB_USERNAME }}
                   password: ${{ secrets.DOCKERHUB_TOKEN }}
 
             - name: Build and push
               id: docker_build
-              uses: docker/build-push-action@v2
+              uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a # v2.10.0 Mar 14, 2022
               with:
                   context: .
                   push: true

--- a/.github/workflows/run-helm-chart-tests-secret-operator.yml
+++ b/.github/workflows/run-helm-chart-tests-secret-operator.yml
@@ -11,22 +11,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0 Aug 24, 2023
         with:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4.2.0
+        uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814 # v4.2.0 Apr 15, 2024
         with:
           version: v3.17.0
 
-      - uses: actions/setup-python@v5.3.0
+      - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0 Oct 24, 2024
         with:
           python-version: "3.x"
           check-latest: true
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.7.0
+        uses: helm/chart-testing-action@0d28d3144d3a25ea2cc349d6e59901c4ff469b3b # v2.7.0 Jan 20, 2025
         with:
           yamale_version: "6.0.0"
 

--- a/.github/workflows/run-helm-chart-tests-secret-operator.yml
+++ b/.github/workflows/run-helm-chart-tests-secret-operator.yml
@@ -34,7 +34,7 @@ jobs:
         run: ct lint --config ct.yaml --charts helm-charts/secrets-operator
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.12.0
+        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0 Dec 23, 2024
 
       - name: Install CRDs first
         run: |


### PR DESCRIPTION
Pinned all workflow dependencies by SHA as they are the only truly immutable state we can target.