### PR TITLE
Add infisicalstaticsecrets finalizer to RBAC

### DIFF
--- a/helm-charts/secrets-operator/templates/manager-rbac.yaml
+++ b/helm-charts/secrets-operator/templates/manager-rbac.yaml
@@ -91,6 +91,7 @@ rules:
   - infisicaldynamicsecrets/finalizers
   - infisicalpushsecrets/finalizers
   - infisicalsecrets/finalizers
+  - infisicalstaticsecrets/finalizers
   verbs:
   - update
 {{- end }}


### PR DESCRIPTION
This permission is required to make `creationPolicy: Owner` work when creating InfisicalStaticSecrets.

Tested in an OpenShift 4.19 Kubernetes cluster.