### PR TITLE
feat: reference secret by path

### DIFF
--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -31,6 +31,15 @@ type SecretTemplateOptions struct {
 	SecretPath string `json:"secretPath"`
 }
 
+type V1TemplateOptions struct {
+	Value      string `json:"value"`
+	SecretPath string `json:"secretPath"`
+}
+
+func (o V1TemplateOptions) String() string {
+	return o.Value
+}
+
 type Project struct {
 	ID           string `json:"id"`
 	Name         string `json:"name"`

--- a/internal/services/infisicalstaticsecret/handler.go
+++ b/internal/services/infisicalstaticsecret/handler.go
@@ -77,7 +77,7 @@ func (h *InfisicalStaticSecretHandler) SyncSecrets(ctx context.Context, infisica
 
 	var totalAffectedWorkloads = 0
 	for _, target := range infisicalStaticSecret.Spec.Targets {
-		affectedWorkloads, err := h.syncTargetSecrets(ctx, infisicalStaticSecret, mergedSecrets, target)
+		affectedWorkloads, err := h.syncTargetSecrets(ctx, infisicalStaticSecret, mergedSecrets, secrets, target)
 		totalAffectedWorkloads += affectedWorkloads
 		if err != nil {
 			setReconcileStatusCondition(infisicalStaticSecret, err)
@@ -228,8 +228,8 @@ func CloseInstantUpdatesStreams(registries map[string]*sse.ConnectionRegistry) {
 	}
 }
 
-func (h *InfisicalStaticSecretHandler) syncTargetSecrets(ctx context.Context, owner *v1beta1.InfisicalStaticSecret, secrets []api.Secret, target v1beta1.SecretTarget) (int, error) {
-	content, err := h.reconciler.RenderTargetOutput(secrets, target)
+func (h *InfisicalStaticSecretHandler) syncTargetSecrets(ctx context.Context, owner *v1beta1.InfisicalStaticSecret, mergedSecrets, rawSecrets []api.Secret, target v1beta1.SecretTarget) (int, error) {
+	content, err := h.reconciler.RenderTargetOutput(mergedSecrets, rawSecrets, target)
 	if err != nil {
 		return 0, fmt.Errorf("failed to render target output: %w", err)
 	}

--- a/internal/services/infisicalstaticsecret/reconciler.go
+++ b/internal/services/infisicalstaticsecret/reconciler.go
@@ -1,14 +1,12 @@
 package infisicalstaticsecret
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"maps"
 	"sort"
 	"strings"
-	tpl "text/template"
 
 	"github.com/Infisical/infisical/k8-operator/api/v1beta1"
 	"github.com/Infisical/infisical/k8-operator/internal/api"
@@ -16,10 +14,10 @@ import (
 	"github.com/Infisical/infisical/k8-operator/internal/constants"
 	"github.com/Infisical/infisical/k8-operator/internal/crypto"
 	"github.com/Infisical/infisical/k8-operator/internal/model"
-	"github.com/Infisical/infisical/k8-operator/internal/template"
+	templatev1 "github.com/Infisical/infisical/k8-operator/internal/template/v1"
 	"github.com/Infisical/infisical/k8-operator/internal/util"
+
 	"github.com/go-logr/logr"
-	"gopkg.in/yaml.v3"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8Errors "k8s.io/apimachinery/pkg/api/errors"
@@ -399,63 +397,10 @@ func (r *InfisicalStaticSecretReconciler) RenderTargetOutput(secrets []api.Secre
 	}
 
 	if target.Template.Data.IsRaw() {
-		return renderBulkTemplate(target.Template.Data.Raw, templateCtx)
+		return templatev1.RenderBulkTemplate(target.Template.Data.Raw, templateCtx)
 	}
 
-	return renderPerKeyTemplates(target.Template.Data.Map, templateCtx)
-}
-
-// renderPerKeyTemplates renders one Go template per map entry. Each entry's
-// rendered output becomes a single key in the resulting Secret / ConfigMap.
-func renderPerKeyTemplates(tmpls map[string]string, ctx map[string]model.SecretTemplateOptions) (map[string][]byte, error) {
-	data := make(map[string][]byte, len(tmpls))
-
-	for key, tmplStr := range tmpls {
-		tmpl, err := tpl.New(key).Funcs(template.GetTemplateFunctions()).Parse(tmplStr)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse template at key %q: %w", key, err)
-		}
-
-		var buf bytes.Buffer
-		if err := tmpl.Execute(&buf, ctx); err != nil {
-			return nil, fmt.Errorf("failed to execute template at key %q: %w", key, err)
-		}
-
-		data[key] = buf.Bytes()
-	}
-
-	return data, nil
-}
-
-// renderBulkTemplate renders a single Go template whose output is parsed as a
-// YAML map of key/value pairs. Each resulting entry becomes one key in the
-// Secret / ConfigMap.
-func renderBulkTemplate(tmplStr string, ctx map[string]model.SecretTemplateOptions) (map[string][]byte, error) {
-	tmpl, err := tpl.New("template.data").Funcs(template.GetTemplateFunctions()).Parse(tmplStr)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse bulk template: %w", err)
-	}
-
-	var buf bytes.Buffer
-	if err := tmpl.Execute(&buf, ctx); err != nil {
-		return nil, fmt.Errorf("failed to execute bulk template: %w", err)
-	}
-
-	rendered := bytes.TrimSpace(buf.Bytes())
-	if len(rendered) == 0 {
-		return map[string][]byte{}, nil
-	}
-
-	var parsed map[string]string
-	if err := yaml.Unmarshal(rendered, &parsed); err != nil {
-		return nil, fmt.Errorf("bulk template output is not a valid YAML map of key/value pairs: %w", err)
-	}
-
-	data := make(map[string][]byte, len(parsed))
-	for k, v := range parsed {
-		data[k] = []byte(v)
-	}
-	return data, nil
+	return templatev1.RenderPerKeyTemplates(target.Template.Data.Map, templateCtx)
 }
 
 // SyncKubeSecret creates or updates a Kubernetes Secret with the secrets content.

--- a/internal/services/infisicalstaticsecret/reconciler.go
+++ b/internal/services/infisicalstaticsecret/reconciler.go
@@ -377,10 +377,10 @@ func (r *InfisicalStaticSecretReconciler) MergeSecretSources(secrets []api.Secre
 	return merged
 }
 
-func (r *InfisicalStaticSecretReconciler) RenderTargetOutput(secrets []api.Secret, target v1beta1.SecretTarget) (map[string][]byte, error) {
+func (r *InfisicalStaticSecretReconciler) RenderTargetOutput(mergedSecrets, rawSecrets []api.Secret, target v1beta1.SecretTarget) (map[string][]byte, error) {
 	data := make(map[string][]byte)
 
-	for _, s := range secrets {
+	for _, s := range mergedSecrets {
 		data[s.SecretKey] = []byte(s.SecretValue)
 	}
 
@@ -388,14 +388,7 @@ func (r *InfisicalStaticSecretReconciler) RenderTargetOutput(secrets []api.Secre
 		return data, nil
 	}
 
-	templateCtx := make(map[string]model.SecretTemplateOptions, len(secrets))
-	for _, s := range secrets {
-		templateCtx[s.SecretKey] = model.SecretTemplateOptions{
-			Value:      s.SecretValue,
-			SecretPath: s.SecretPath,
-		}
-	}
-
+	templateCtx := templatev1.NewTemplateContext(rawSecrets, mergedSecrets)
 	if target.Template.Data.IsRaw() {
 		return templatev1.RenderBulkTemplate(target.Template.Data.Raw, templateCtx)
 	}

--- a/internal/services/infisicalstaticsecret/reconciler_test.go
+++ b/internal/services/infisicalstaticsecret/reconciler_test.go
@@ -377,7 +377,7 @@ var _ = Describe("RenderTargetOutput", func() {
 			Expect(err.Error()).To(ContainSubstring("failed to parse template"))
 		})
 
-		It("renders template using getSecretByPath to reference secrets in subfolders", func() {
+		It("renders template using secretFrom to reference secrets in subfolders", func() {
 			subfolderSecrets := []api.Secret{
 				{SecretKey: "DB_HOST", SecretValue: "prod-db.example.com", SecretPath: "/folder/subfolder"},
 				{SecretKey: "DB_PORT", SecretValue: "5432", SecretPath: "/folder/subfolder"},
@@ -391,8 +391,8 @@ var _ = Describe("RenderTargetOutput", func() {
 				Template: &v1beta1.SecretTemplate{
 					Data: v1beta1.SecretTemplateData{
 						Map: map[string]string{
-							"dsn":     `postgresql://user:pass@{{ getSecretByPath "folder/subfolder/DB_HOST" }}:{{ getSecretByPath "folder/subfolder/DB_PORT" }}/mydb`,
-							"api_key": `{{ getSecretByPath "folder/other/API_KEY" }}`,
+							"dsn":     `postgresql://user:pass@{{ secretFrom "/folder/subfolder" "DB_HOST" }}:{{ secretFrom "/folder/subfolder" "DB_PORT" }}/mydb`,
+							"api_key": `{{ secretFrom "/folder/other" "API_KEY" }}`,
 						},
 					},
 				},

--- a/internal/services/infisicalstaticsecret/reconciler_test.go
+++ b/internal/services/infisicalstaticsecret/reconciler_test.go
@@ -376,6 +376,34 @@ var _ = Describe("RenderTargetOutput", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("failed to parse template"))
 		})
+
+		It("renders template using secretRef to reference secrets in subfolders", func() {
+			subfolderSecrets := []api.Secret{
+				{SecretKey: "DB_HOST", SecretValue: "prod-db.example.com", SecretPath: "/folder/subfolder"},
+				{SecretKey: "DB_PORT", SecretValue: "5432", SecretPath: "/folder/subfolder"},
+				{SecretKey: "API_KEY", SecretValue: "sk-secret-123", SecretPath: "/folder/other"},
+			}
+
+			target := v1beta1.SecretTarget{
+				Name:      "ref-test",
+				Namespace: "default",
+				Kind:      v1beta1.SecretTargetKindSecret,
+				Template: &v1beta1.SecretTemplate{
+					Data: v1beta1.SecretTemplateData{
+						Map: map[string]string{
+							"dsn":     `postgresql://user:pass@{{ secretRef "folder.subfolder.DB_HOST.value" }}:{{ secretRef "folder.subfolder.DB_PORT.value" }}/mydb`,
+							"api_key": `{{ secretRef "folder.other.API_KEY.value" }}`,
+						},
+					},
+				},
+			}
+
+			data, err := reconciler.RenderTargetOutput(subfolderSecrets, target)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(data).To(HaveLen(2))
+			Expect(data).To(HaveKeyWithValue("dsn", []byte("postgresql://user:pass@prod-db.example.com:5432/mydb")))
+			Expect(data).To(HaveKeyWithValue("api_key", []byte("sk-secret-123")))
+		})
 	})
 
 	Context("with a bulk (string) template", func() {

--- a/internal/services/infisicalstaticsecret/reconciler_test.go
+++ b/internal/services/infisicalstaticsecret/reconciler_test.go
@@ -377,7 +377,7 @@ var _ = Describe("RenderTargetOutput", func() {
 			Expect(err.Error()).To(ContainSubstring("failed to parse template"))
 		})
 
-		It("renders template using secretRef to reference secrets in subfolders", func() {
+		It("renders template using resolveSecretFromPath to reference secrets in subfolders", func() {
 			subfolderSecrets := []api.Secret{
 				{SecretKey: "DB_HOST", SecretValue: "prod-db.example.com", SecretPath: "/folder/subfolder"},
 				{SecretKey: "DB_PORT", SecretValue: "5432", SecretPath: "/folder/subfolder"},
@@ -391,8 +391,8 @@ var _ = Describe("RenderTargetOutput", func() {
 				Template: &v1beta1.SecretTemplate{
 					Data: v1beta1.SecretTemplateData{
 						Map: map[string]string{
-							"dsn":     `postgresql://user:pass@{{ secretRef "folder.subfolder.DB_HOST.value" }}:{{ secretRef "folder.subfolder.DB_PORT.value" }}/mydb`,
-							"api_key": `{{ secretRef "folder.other.API_KEY.value" }}`,
+							"dsn":     `postgresql://user:pass@{{ resolveSecretFromPath "folder.subfolder.DB_HOST.value" }}:{{ resolveSecretFromPath "folder.subfolder.DB_PORT.value" }}/mydb`,
+							"api_key": `{{ resolveSecretFromPath "folder.other.API_KEY.value" }}`,
 						},
 					},
 				},

--- a/internal/services/infisicalstaticsecret/reconciler_test.go
+++ b/internal/services/infisicalstaticsecret/reconciler_test.go
@@ -377,7 +377,7 @@ var _ = Describe("RenderTargetOutput", func() {
 			Expect(err.Error()).To(ContainSubstring("failed to parse template"))
 		})
 
-		It("renders template using resolveSecretFromPath to reference secrets in subfolders", func() {
+		It("renders template using getSecretByPath to reference secrets in subfolders", func() {
 			subfolderSecrets := []api.Secret{
 				{SecretKey: "DB_HOST", SecretValue: "prod-db.example.com", SecretPath: "/folder/subfolder"},
 				{SecretKey: "DB_PORT", SecretValue: "5432", SecretPath: "/folder/subfolder"},
@@ -391,8 +391,8 @@ var _ = Describe("RenderTargetOutput", func() {
 				Template: &v1beta1.SecretTemplate{
 					Data: v1beta1.SecretTemplateData{
 						Map: map[string]string{
-							"dsn":     `postgresql://user:pass@{{ resolveSecretFromPath "folder.subfolder.DB_HOST.value" }}:{{ resolveSecretFromPath "folder.subfolder.DB_PORT.value" }}/mydb`,
-							"api_key": `{{ resolveSecretFromPath "folder.other.API_KEY.value" }}`,
+							"dsn":     `postgresql://user:pass@{{ getSecretByPath "folder/subfolder/DB_HOST" }}:{{ getSecretByPath "folder/subfolder/DB_PORT" }}/mydb`,
+							"api_key": `{{ getSecretByPath "folder/other/API_KEY" }}`,
 						},
 					},
 				},

--- a/internal/services/infisicalstaticsecret/reconciler_test.go
+++ b/internal/services/infisicalstaticsecret/reconciler_test.go
@@ -275,7 +275,7 @@ var _ = Describe("RenderTargetOutput", func() {
 				Kind:      v1beta1.SecretTargetKindSecret,
 			}
 
-			data, err := reconciler.RenderTargetOutput(secrets, target)
+			data, err := reconciler.RenderTargetOutput(secrets, secrets, target)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(data).To(HaveLen(3))
 			Expect(data).To(HaveKeyWithValue("DB_HOST", []byte("localhost")))
@@ -290,7 +290,7 @@ var _ = Describe("RenderTargetOutput", func() {
 				Kind:      v1beta1.SecretTargetKindSecret,
 			}
 
-			data, err := reconciler.RenderTargetOutput([]api.Secret{}, target)
+			data, err := reconciler.RenderTargetOutput([]api.Secret{}, []api.Secret{}, target)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(data).To(BeEmpty())
 		})
@@ -311,7 +311,7 @@ var _ = Describe("RenderTargetOutput", func() {
 				},
 			}
 
-			data, err := reconciler.RenderTargetOutput(secrets, target)
+			data, err := reconciler.RenderTargetOutput(secrets, secrets, target)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(data).To(HaveLen(1))
 			Expect(data).To(HaveKeyWithValue("dsn", []byte("postgresql://user:pass@localhost:5432/mydb")))
@@ -331,7 +331,7 @@ var _ = Describe("RenderTargetOutput", func() {
 				},
 			}
 
-			data, err := reconciler.RenderTargetOutput(secrets, target)
+			data, err := reconciler.RenderTargetOutput(secrets, secrets, target)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(data).To(HaveKeyWithValue("info", []byte("localhost from /db")))
 		})
@@ -351,7 +351,7 @@ var _ = Describe("RenderTargetOutput", func() {
 				},
 			}
 
-			data, err := reconciler.RenderTargetOutput(secrets, target)
+			data, err := reconciler.RenderTargetOutput(secrets, secrets, target)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(data).To(HaveLen(2))
 			Expect(data).To(HaveKeyWithValue("host", []byte("localhost")))
@@ -372,7 +372,7 @@ var _ = Describe("RenderTargetOutput", func() {
 				},
 			}
 
-			_, err := reconciler.RenderTargetOutput(secrets, target)
+			_, err := reconciler.RenderTargetOutput(secrets, secrets, target)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("failed to parse template"))
 		})
@@ -398,7 +398,7 @@ var _ = Describe("RenderTargetOutput", func() {
 				},
 			}
 
-			data, err := reconciler.RenderTargetOutput(subfolderSecrets, target)
+			data, err := reconciler.RenderTargetOutput(subfolderSecrets, subfolderSecrets, target)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(data).To(HaveLen(2))
 			Expect(data).To(HaveKeyWithValue("dsn", []byte("postgresql://user:pass@prod-db.example.com:5432/mydb")))
@@ -421,7 +421,7 @@ var _ = Describe("RenderTargetOutput", func() {
 				},
 			}
 
-			data, err := reconciler.RenderTargetOutput(secrets, target)
+			data, err := reconciler.RenderTargetOutput(secrets, secrets, target)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(data).To(HaveLen(3))
 			Expect(data).To(HaveKeyWithValue("DB_HOST", []byte("localhost")))
@@ -442,7 +442,7 @@ COUNT: "{{ len . }}"`,
 				},
 			}
 
-			data, err := reconciler.RenderTargetOutput(secrets, target)
+			data, err := reconciler.RenderTargetOutput(secrets, secrets, target)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(data).To(HaveKeyWithValue("DSN", []byte("postgres://localhost:5432/mydb")))
 			Expect(data).To(HaveKeyWithValue("COUNT", []byte("3")))
@@ -458,7 +458,7 @@ COUNT: "{{ len . }}"`,
 				},
 			}
 
-			data, err := reconciler.RenderTargetOutput(secrets, target)
+			data, err := reconciler.RenderTargetOutput(secrets, secrets, target)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(data).To(BeEmpty())
 		})
@@ -473,7 +473,7 @@ COUNT: "{{ len . }}"`,
 				},
 			}
 
-			_, err := reconciler.RenderTargetOutput(secrets, target)
+			_, err := reconciler.RenderTargetOutput(secrets, secrets, target)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("failed to parse bulk template"))
 		})
@@ -490,7 +490,7 @@ COUNT: "{{ len . }}"`,
 				},
 			}
 
-			_, err := reconciler.RenderTargetOutput(secrets, target)
+			_, err := reconciler.RenderTargetOutput(secrets, secrets, target)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("bulk template output is not a valid YAML map"))
 		})

--- a/internal/template/template.go
+++ b/internal/template/template.go
@@ -63,5 +63,11 @@ func InitializeTemplateFunctions() {
 }
 
 func GetTemplateFunctions() tpl.FuncMap {
-	return customInfisicalSecretTemplateFunctions
+	copy := make(tpl.FuncMap, len(customInfisicalSecretTemplateFunctions))
+	// secretFrom modifies the tpl.FuncMap, so to prevent data race conditions and go to panic,
+	// we copy the map to return it as value.
+	for k, v := range customInfisicalSecretTemplateFunctions {
+		copy[k] = v
+	}
+	return copy
 }

--- a/internal/template/v1/suite_test.go
+++ b/internal/template/v1/suite_test.go
@@ -1,0 +1,13 @@
+package v1_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestTemplateV1(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Template V1 Suite")
+}

--- a/internal/template/v1/template.go
+++ b/internal/template/v1/template.go
@@ -81,8 +81,25 @@ func RenderBulkTemplate(tmplStr string, ctx TemplateContext) (map[string][]byte,
 	return data, nil
 }
 
-func BuildSecretTree(ctx TemplateContext) map[string]any {
-	root := make(map[string]any)
+type SecretTreeNode struct {
+	Secret   *model.V1TemplateOptions
+	Children map[string]*SecretTreeNode
+}
+
+func (n *SecretTreeNode) getOrCreateChild(key string) *SecretTreeNode {
+	if n.Children == nil {
+		n.Children = make(map[string]*SecretTreeNode)
+	}
+	child, exists := n.Children[key]
+	if !exists {
+		child = &SecretTreeNode{}
+		n.Children[key] = child
+	}
+	return child
+}
+
+func BuildSecretTree(ctx TemplateContext) *SecretTreeNode {
+	root := &SecretTreeNode{}
 
 	for _, s := range ctx.rawSecrets {
 		segments := strings.Split(strings.Trim(s.SecretPath, "/"), "/")
@@ -92,16 +109,12 @@ func BuildSecretTree(ctx TemplateContext) map[string]any {
 			if seg == "" {
 				continue
 			}
-			child, exists := node[seg]
-			if !exists {
-				child = make(map[string]any)
-				node[seg] = child
-			}
-			node = child.(map[string]any)
+			node = node.getOrCreateChild(seg)
 		}
 
-		if _, exists := node[s.SecretKey]; !exists {
-			node[s.SecretKey] = model.V1TemplateOptions{
+		leaf := node.getOrCreateChild(s.SecretKey)
+		if leaf.Secret == nil {
+			leaf.Secret = &model.V1TemplateOptions{
 				Value:      s.SecretValue,
 				SecretPath: s.SecretPath,
 			}
@@ -115,36 +128,32 @@ func newTemplate(name, templateString string, ctx TemplateContext) (*tpl.Templat
 	funcs := template.GetTemplateFunctions()
 	tree := BuildSecretTree(ctx)
 	funcs["secretFrom"] = func(secretPath, secretName string) (model.V1TemplateOptions, error) {
-		var current any = tree
+		current := tree
 		for _, seg := range strings.Split(strings.Trim(secretPath, "/"), "/") {
 			if seg == "" {
 				continue
 			}
-			node, ok := current.(map[string]any)
-			if !ok {
-				return model.V1TemplateOptions{}, fmt.Errorf("secretFrom: segment %q is not a folder", seg)
+			if current.Children == nil {
+				return model.V1TemplateOptions{}, fmt.Errorf("secretFrom: segment %q not found", seg)
 			}
-			child, exists := node[seg]
+			child, exists := current.Children[seg]
 			if !exists {
 				return model.V1TemplateOptions{}, fmt.Errorf("secretFrom: segment %q not found", seg)
 			}
 			current = child
 		}
 
-		node, ok := current.(map[string]any)
-		if !ok {
-			return model.V1TemplateOptions{}, fmt.Errorf("secretFrom: path does not resolve to a folder")
+		if current.Children == nil {
+			return model.V1TemplateOptions{}, fmt.Errorf("secretFrom: secret %q not found", secretName)
 		}
-		val, exists := node[secretName]
+		child, exists := current.Children[secretName]
 		if !exists {
 			return model.V1TemplateOptions{}, fmt.Errorf("secretFrom: secret %q not found", secretName)
 		}
-		opts, ok := val.(model.V1TemplateOptions)
-		if !ok {
+		if child.Secret == nil {
 			return model.V1TemplateOptions{}, fmt.Errorf("secretFrom: %q does not resolve to a secret", secretName)
 		}
-
-		return opts, nil
+		return *child.Secret, nil
 	}
 	return tpl.New(name).Funcs(funcs).Parse(templateString)
 }

--- a/internal/template/v1/template.go
+++ b/internal/template/v1/template.go
@@ -114,28 +114,45 @@ func BuildSecretTree(ctx TemplateContext) map[string]any {
 func newTemplate(name, templateString string, ctx TemplateContext) (*tpl.Template, error) {
 	funcs := template.GetTemplateFunctions()
 	tree := BuildSecretTree(ctx)
-	funcs["getSecretByPath"] = func(ref string) (model.V1TemplateOptions, error) {
-		parts := strings.Split(ref, "/")
-		if len(parts) < 1 {
-			return model.V1TemplateOptions{}, fmt.Errorf("getSecretByPath %q: path must not be empty", ref)
+	funcs["secretFrom"] = func(args ...string) (model.V1TemplateOptions, error) {
+		var secretPath, secretName string
+		switch len(args) {
+		case 1:
+			secretName = args[0]
+		case 2:
+			secretPath = args[0]
+			secretName = args[1]
+		default:
+			return model.V1TemplateOptions{}, fmt.Errorf("secretFrom: expected 1 or 2 arguments, got %d", len(args))
 		}
 
 		var current any = tree
-		for _, p := range parts {
+		for _, seg := range strings.Split(strings.Trim(secretPath, "/"), "/") {
+			if seg == "" {
+				continue
+			}
 			node, ok := current.(map[string]any)
 			if !ok {
-				return model.V1TemplateOptions{}, fmt.Errorf("getSecretByPath %q: segment %q is not a folder", ref, p)
+				return model.V1TemplateOptions{}, fmt.Errorf("secretFrom: segment %q is not a folder", seg)
 			}
-			child, exists := node[p]
+			child, exists := node[seg]
 			if !exists {
-				return model.V1TemplateOptions{}, fmt.Errorf("getSecretByPath %q: segment %q not found", ref, p)
+				return model.V1TemplateOptions{}, fmt.Errorf("secretFrom: segment %q not found", seg)
 			}
 			current = child
 		}
 
-		opts, ok := current.(model.V1TemplateOptions)
+		node, ok := current.(map[string]any)
 		if !ok {
-			return model.V1TemplateOptions{}, fmt.Errorf("getSecretByPath %q: does not resolve to a secret", ref)
+			return model.V1TemplateOptions{}, fmt.Errorf("secretFrom: path does not resolve to a folder")
+		}
+		val, exists := node[secretName]
+		if !exists {
+			return model.V1TemplateOptions{}, fmt.Errorf("secretFrom: secret %q not found", secretName)
+		}
+		opts, ok := val.(model.V1TemplateOptions)
+		if !ok {
+			return model.V1TemplateOptions{}, fmt.Errorf("secretFrom: %q does not resolve to a secret", secretName)
 		}
 
 		return opts, nil

--- a/internal/template/v1/template.go
+++ b/internal/template/v1/template.go
@@ -6,12 +6,34 @@ import (
 	"strings"
 	tpl "text/template"
 
+	"github.com/Infisical/infisical/k8-operator/internal/api"
 	"github.com/Infisical/infisical/k8-operator/internal/model"
 	"github.com/Infisical/infisical/k8-operator/internal/template"
 	"gopkg.in/yaml.v3"
 )
 
-func RenderPerKeyTemplates(tmpls map[string]string, ctx map[string]model.SecretTemplateOptions) (map[string][]byte, error) {
+type TemplateContext struct {
+	rawSecrets    []api.Secret
+	mergedSecrets map[string]model.SecretTemplateOptions
+}
+
+func NewTemplateContext(rawSecrets []api.Secret, mergedSecrets []api.Secret) TemplateContext {
+	ctx := TemplateContext{
+		rawSecrets:    rawSecrets,
+		mergedSecrets: make(map[string]model.SecretTemplateOptions, 0),
+	}
+
+	for _, s := range mergedSecrets {
+		ctx.mergedSecrets[s.SecretKey] = model.SecretTemplateOptions{
+			Value:      s.SecretValue,
+			SecretPath: s.SecretPath,
+		}
+	}
+
+	return ctx
+}
+
+func RenderPerKeyTemplates(tmpls map[string]string, ctx TemplateContext) (map[string][]byte, error) {
 	data := make(map[string][]byte, len(tmpls))
 
 	for key, tmplStr := range tmpls {
@@ -21,7 +43,7 @@ func RenderPerKeyTemplates(tmpls map[string]string, ctx map[string]model.SecretT
 		}
 
 		var buf bytes.Buffer
-		if err := tmpl.Execute(&buf, ctx); err != nil {
+		if err := tmpl.Execute(&buf, ctx.mergedSecrets); err != nil {
 			return nil, fmt.Errorf("failed to execute template at key %q: %w", key, err)
 		}
 
@@ -31,14 +53,14 @@ func RenderPerKeyTemplates(tmpls map[string]string, ctx map[string]model.SecretT
 	return data, nil
 }
 
-func RenderBulkTemplate(tmplStr string, ctx map[string]model.SecretTemplateOptions) (map[string][]byte, error) {
+func RenderBulkTemplate(tmplStr string, ctx TemplateContext) (map[string][]byte, error) {
 	tmpl, err := newTemplate("template.data", tmplStr, ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse bulk template: %w", err)
 	}
 
 	var buf bytes.Buffer
-	if err := tmpl.Execute(&buf, ctx); err != nil {
+	if err := tmpl.Execute(&buf, ctx.mergedSecrets); err != nil {
 		return nil, fmt.Errorf("failed to execute bulk template: %w", err)
 	}
 
@@ -59,12 +81,11 @@ func RenderBulkTemplate(tmplStr string, ctx map[string]model.SecretTemplateOptio
 	return data, nil
 }
 
-func BuildSecretTree(ctx map[string]model.SecretTemplateOptions) map[string]any {
+func BuildSecretTree(ctx TemplateContext) map[string]any {
 	root := make(map[string]any)
 
-	for key, opts := range ctx {
-		path := opts.SecretPath
-		segments := strings.Split(strings.Trim(path, "/"), "/")
+	for _, s := range ctx.rawSecrets {
+		segments := strings.Split(strings.Trim(s.SecretPath, "/"), "/")
 
 		node := root
 		for _, seg := range segments {
@@ -79,13 +100,16 @@ func BuildSecretTree(ctx map[string]model.SecretTemplateOptions) map[string]any 
 			node = child.(map[string]any)
 		}
 
-		node[key] = opts
+		node[s.SecretKey] = model.SecretTemplateOptions{
+			Value:      s.SecretValue,
+			SecretPath: s.SecretPath,
+		}
 	}
 
 	return root
 }
 
-func newTemplate(name, templateString string, ctx map[string]model.SecretTemplateOptions) (*tpl.Template, error) {
+func newTemplate(name, templateString string, ctx TemplateContext) (*tpl.Template, error) {
 	funcs := template.GetTemplateFunctions()
 	tree := BuildSecretTree(ctx)
 	funcs["resolveSecretFromPath"] = func(ref string) (string, error) {

--- a/internal/template/v1/template.go
+++ b/internal/template/v1/template.go
@@ -88,10 +88,10 @@ func BuildSecretTree(ctx map[string]model.SecretTemplateOptions) map[string]any 
 func newTemplate(name, templateString string, ctx map[string]model.SecretTemplateOptions) (*tpl.Template, error) {
 	funcs := template.GetTemplateFunctions()
 	tree := BuildSecretTree(ctx)
-	funcs["secretRef"] = func(ref string) (string, error) {
+	funcs["resolveSecretFromPath"] = func(ref string) (string, error) {
 		parts := strings.Split(ref, ".")
 		if len(parts) < 2 {
-			return "", fmt.Errorf("secretRef %q must have at least a secret name and accessor (value or secretPath)", ref)
+			return "", fmt.Errorf("resolveSecretFromPath %q must have at least a secret name and accessor (value or secretPath)", ref)
 		}
 
 		accessor := parts[len(parts)-1]
@@ -101,18 +101,18 @@ func newTemplate(name, templateString string, ctx map[string]model.SecretTemplat
 		for _, p := range pathParts {
 			node, ok := current.(map[string]any)
 			if !ok {
-				return "", fmt.Errorf("secretRef %q: segment %q is not a folder", ref, p)
+				return "", fmt.Errorf("resolveSecretFromPath %q: segment %q is not a folder", ref, p)
 			}
 			child, exists := node[p]
 			if !exists {
-				return "", fmt.Errorf("secretRef %q: segment %q not found", ref, p)
+				return "", fmt.Errorf("resolveSecretFromPath %q: segment %q not found", ref, p)
 			}
 			current = child
 		}
 
 		opts, ok := current.(model.SecretTemplateOptions)
 		if !ok {
-			return "", fmt.Errorf("secretRef %q: does not resolve to a secret", ref)
+			return "", fmt.Errorf("resolveSecretFromPath %q: does not resolve to a secret", ref)
 		}
 
 		switch strings.ToLower(accessor) {
@@ -121,7 +121,7 @@ func newTemplate(name, templateString string, ctx map[string]model.SecretTemplat
 		case "secretpath":
 			return opts.SecretPath, nil
 		default:
-			return "", fmt.Errorf("secretRef %q: unknown accessor %q (use value or secretPath)", ref, accessor)
+			return "", fmt.Errorf("resolveSecretFromPath %q: unknown accessor %q (use value or secretPath)", ref, accessor)
 		}
 	}
 	return tpl.New(name).Funcs(funcs).Parse(templateString)

--- a/internal/template/v1/template.go
+++ b/internal/template/v1/template.go
@@ -100,9 +100,11 @@ func BuildSecretTree(ctx TemplateContext) map[string]any {
 			node = child.(map[string]any)
 		}
 
-		node[s.SecretKey] = model.SecretTemplateOptions{
-			Value:      s.SecretValue,
-			SecretPath: s.SecretPath,
+		if _, exists := node[s.SecretKey]; !exists {
+			node[s.SecretKey] = model.SecretTemplateOptions{
+				Value:      s.SecretValue,
+				SecretPath: s.SecretPath,
+			}
 		}
 	}
 

--- a/internal/template/v1/template.go
+++ b/internal/template/v1/template.go
@@ -114,18 +114,7 @@ func BuildSecretTree(ctx TemplateContext) map[string]any {
 func newTemplate(name, templateString string, ctx TemplateContext) (*tpl.Template, error) {
 	funcs := template.GetTemplateFunctions()
 	tree := BuildSecretTree(ctx)
-	funcs["secretFrom"] = func(args ...string) (model.V1TemplateOptions, error) {
-		var secretPath, secretName string
-		switch len(args) {
-		case 1:
-			secretName = args[0]
-		case 2:
-			secretPath = args[0]
-			secretName = args[1]
-		default:
-			return model.V1TemplateOptions{}, fmt.Errorf("secretFrom: expected 1 or 2 arguments, got %d", len(args))
-		}
-
+	funcs["secretFrom"] = func(secretPath, secretName string) (model.V1TemplateOptions, error) {
 		var current any = tree
 		for _, seg := range strings.Split(strings.Trim(secretPath, "/"), "/") {
 			if seg == "" {

--- a/internal/template/v1/template.go
+++ b/internal/template/v1/template.go
@@ -1,0 +1,128 @@
+package v1
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	tpl "text/template"
+
+	"github.com/Infisical/infisical/k8-operator/internal/model"
+	"github.com/Infisical/infisical/k8-operator/internal/template"
+	"gopkg.in/yaml.v3"
+)
+
+func RenderPerKeyTemplates(tmpls map[string]string, ctx map[string]model.SecretTemplateOptions) (map[string][]byte, error) {
+	data := make(map[string][]byte, len(tmpls))
+
+	for key, tmplStr := range tmpls {
+		tmpl, err := newTemplate(key, tmplStr, ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse template at key %q: %w", key, err)
+		}
+
+		var buf bytes.Buffer
+		if err := tmpl.Execute(&buf, ctx); err != nil {
+			return nil, fmt.Errorf("failed to execute template at key %q: %w", key, err)
+		}
+
+		data[key] = buf.Bytes()
+	}
+
+	return data, nil
+}
+
+func RenderBulkTemplate(tmplStr string, ctx map[string]model.SecretTemplateOptions) (map[string][]byte, error) {
+	tmpl, err := newTemplate("template.data", tmplStr, ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse bulk template: %w", err)
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, ctx); err != nil {
+		return nil, fmt.Errorf("failed to execute bulk template: %w", err)
+	}
+
+	rendered := bytes.TrimSpace(buf.Bytes())
+	if len(rendered) == 0 {
+		return map[string][]byte{}, nil
+	}
+
+	var parsed map[string]string
+	if err := yaml.Unmarshal(rendered, &parsed); err != nil {
+		return nil, fmt.Errorf("bulk template output is not a valid YAML map of key/value pairs: %w", err)
+	}
+
+	data := make(map[string][]byte, len(parsed))
+	for k, v := range parsed {
+		data[k] = []byte(v)
+	}
+	return data, nil
+}
+
+func BuildSecretTree(ctx map[string]model.SecretTemplateOptions) map[string]any {
+	root := make(map[string]any)
+
+	for key, opts := range ctx {
+		path := opts.SecretPath
+		segments := strings.Split(strings.Trim(path, "/"), "/")
+
+		node := root
+		for _, seg := range segments {
+			if seg == "" {
+				continue
+			}
+			child, exists := node[seg]
+			if !exists {
+				child = make(map[string]any)
+				node[seg] = child
+			}
+			node = child.(map[string]any)
+		}
+
+		node[key] = opts
+	}
+
+	return root
+}
+
+func newTemplate(name, templateString string, ctx map[string]model.SecretTemplateOptions) (*tpl.Template, error) {
+	funcs := template.GetTemplateFunctions()
+	tree := BuildSecretTree(ctx)
+	funcs["secretRef"] = func(ref string) (string, error) {
+		parts := strings.Split(ref, ".")
+		if len(parts) < 2 {
+			return "", fmt.Errorf("secretRef %q must have at least a secret name and accessor (value or secretPath)", ref)
+		}
+
+		accessor := parts[len(parts)-1]
+		pathParts := parts[:len(parts)-1]
+
+		var current any = tree
+		for _, p := range pathParts {
+			node, ok := current.(map[string]any)
+			if !ok {
+				return "", fmt.Errorf("secretRef %q: segment %q is not a folder", ref, p)
+			}
+			child, exists := node[p]
+			if !exists {
+				return "", fmt.Errorf("secretRef %q: segment %q not found", ref, p)
+			}
+			current = child
+		}
+
+		opts, ok := current.(model.SecretTemplateOptions)
+		if !ok {
+			return "", fmt.Errorf("secretRef %q: does not resolve to a secret", ref)
+		}
+
+		switch strings.ToLower(accessor) {
+		case "value":
+			return opts.Value, nil
+		case "secretpath":
+			return opts.SecretPath, nil
+		default:
+			return "", fmt.Errorf("secretRef %q: unknown accessor %q (use value or secretPath)", ref, accessor)
+		}
+	}
+	return tpl.New(name).Funcs(funcs).Parse(templateString)
+}

--- a/internal/template/v1/template.go
+++ b/internal/template/v1/template.go
@@ -14,17 +14,17 @@ import (
 
 type TemplateContext struct {
 	rawSecrets    []api.Secret
-	mergedSecrets map[string]model.SecretTemplateOptions
+	mergedSecrets map[string]model.V1TemplateOptions
 }
 
 func NewTemplateContext(rawSecrets []api.Secret, mergedSecrets []api.Secret) TemplateContext {
 	ctx := TemplateContext{
 		rawSecrets:    rawSecrets,
-		mergedSecrets: make(map[string]model.SecretTemplateOptions, 0),
+		mergedSecrets: make(map[string]model.V1TemplateOptions, 0),
 	}
 
 	for _, s := range mergedSecrets {
-		ctx.mergedSecrets[s.SecretKey] = model.SecretTemplateOptions{
+		ctx.mergedSecrets[s.SecretKey] = model.V1TemplateOptions{
 			Value:      s.SecretValue,
 			SecretPath: s.SecretPath,
 		}
@@ -101,7 +101,7 @@ func BuildSecretTree(ctx TemplateContext) map[string]any {
 		}
 
 		if _, exists := node[s.SecretKey]; !exists {
-			node[s.SecretKey] = model.SecretTemplateOptions{
+			node[s.SecretKey] = model.V1TemplateOptions{
 				Value:      s.SecretValue,
 				SecretPath: s.SecretPath,
 			}
@@ -114,41 +114,31 @@ func BuildSecretTree(ctx TemplateContext) map[string]any {
 func newTemplate(name, templateString string, ctx TemplateContext) (*tpl.Template, error) {
 	funcs := template.GetTemplateFunctions()
 	tree := BuildSecretTree(ctx)
-	funcs["resolveSecretFromPath"] = func(ref string) (string, error) {
-		parts := strings.Split(ref, ".")
-		if len(parts) < 2 {
-			return "", fmt.Errorf("resolveSecretFromPath %q must have at least a secret name and accessor (value or secretPath)", ref)
+	funcs["getSecretByPath"] = func(ref string) (model.V1TemplateOptions, error) {
+		parts := strings.Split(ref, "/")
+		if len(parts) < 1 {
+			return model.V1TemplateOptions{}, fmt.Errorf("getSecretByPath %q: path must not be empty", ref)
 		}
 
-		accessor := parts[len(parts)-1]
-		pathParts := parts[:len(parts)-1]
-
 		var current any = tree
-		for _, p := range pathParts {
+		for _, p := range parts {
 			node, ok := current.(map[string]any)
 			if !ok {
-				return "", fmt.Errorf("resolveSecretFromPath %q: segment %q is not a folder", ref, p)
+				return model.V1TemplateOptions{}, fmt.Errorf("getSecretByPath %q: segment %q is not a folder", ref, p)
 			}
 			child, exists := node[p]
 			if !exists {
-				return "", fmt.Errorf("resolveSecretFromPath %q: segment %q not found", ref, p)
+				return model.V1TemplateOptions{}, fmt.Errorf("getSecretByPath %q: segment %q not found", ref, p)
 			}
 			current = child
 		}
 
-		opts, ok := current.(model.SecretTemplateOptions)
+		opts, ok := current.(model.V1TemplateOptions)
 		if !ok {
-			return "", fmt.Errorf("resolveSecretFromPath %q: does not resolve to a secret", ref)
+			return model.V1TemplateOptions{}, fmt.Errorf("getSecretByPath %q: does not resolve to a secret", ref)
 		}
 
-		switch strings.ToLower(accessor) {
-		case "value":
-			return opts.Value, nil
-		case "secretpath":
-			return opts.SecretPath, nil
-		default:
-			return "", fmt.Errorf("resolveSecretFromPath %q: unknown accessor %q (use value or secretPath)", ref, accessor)
-		}
+		return opts, nil
 	}
 	return tpl.New(name).Funcs(funcs).Parse(templateString)
 }

--- a/internal/template/v1/template_test.go
+++ b/internal/template/v1/template_test.go
@@ -40,12 +40,12 @@ var _ = Describe("BuildSecretTree", func() {
 
 		subfolder, ok := folder["subfolder"].(map[string]any)
 		Expect(ok).To(BeTrue())
-		Expect(subfolder["SECRET_1"]).To(Equal(model.SecretTemplateOptions{Value: "val1", SecretPath: "/folder/subfolder"}))
-		Expect(subfolder["SECRET_2"]).To(Equal(model.SecretTemplateOptions{Value: "val2", SecretPath: "/folder/subfolder"}))
+		Expect(subfolder["SECRET_1"]).To(Equal(model.V1TemplateOptions{Value: "val1", SecretPath: "/folder/subfolder"}))
+		Expect(subfolder["SECRET_2"]).To(Equal(model.V1TemplateOptions{Value: "val2", SecretPath: "/folder/subfolder"}))
 
 		another, ok := folder["another"].(map[string]any)
 		Expect(ok).To(BeTrue())
-		Expect(another["SECRET_3"]).To(Equal(model.SecretTemplateOptions{Value: "val3", SecretPath: "/folder/another"}))
+		Expect(another["SECRET_3"]).To(Equal(model.V1TemplateOptions{Value: "val3", SecretPath: "/folder/another"}))
 	})
 
 	It("places secrets at the root path", func() {
@@ -54,7 +54,7 @@ var _ = Describe("BuildSecretTree", func() {
 		}, nil)
 
 		tree := v1.BuildSecretTree(ctx)
-		Expect(tree["ROOT_SECRET"]).To(Equal(model.SecretTemplateOptions{Value: "root-val", SecretPath: "/"}))
+		Expect(tree["ROOT_SECRET"]).To(Equal(model.V1TemplateOptions{Value: "root-val", SecretPath: "/"}))
 	})
 
 	It("returns an empty tree for empty context", func() {
@@ -78,7 +78,7 @@ var _ = Describe("BuildSecretTree", func() {
 		Expect(ok).To(BeTrue())
 		d, ok := c["d"].(map[string]any)
 		Expect(ok).To(BeTrue())
-		Expect(d["DEEP"]).To(Equal(model.SecretTemplateOptions{Value: "deep-val", SecretPath: "/a/b/c/d"}))
+		Expect(d["DEEP"]).To(Equal(model.V1TemplateOptions{Value: "deep-val", SecretPath: "/a/b/c/d"}))
 	})
 
 	It("keeps first occurrence when duplicate keys exist at the same path", func() {
@@ -94,13 +94,13 @@ var _ = Describe("BuildSecretTree", func() {
 
 		shared, ok := tree["shared"].(map[string]any)
 		Expect(ok).To(BeTrue())
-		Expect(shared["DB_HOST"]).To(Equal(model.SecretTemplateOptions{Value: "project-a-host", SecretPath: "/shared"}))
-		Expect(shared["DB_PORT"]).To(Equal(model.SecretTemplateOptions{Value: "5432", SecretPath: "/shared"}))
-		Expect(shared["API_KEY"]).To(Equal(model.SecretTemplateOptions{Value: "key-from-b", SecretPath: "/shared"}))
+		Expect(shared["DB_HOST"]).To(Equal(model.V1TemplateOptions{Value: "project-a-host", SecretPath: "/shared"}))
+		Expect(shared["DB_PORT"]).To(Equal(model.V1TemplateOptions{Value: "5432", SecretPath: "/shared"}))
+		Expect(shared["API_KEY"]).To(Equal(model.V1TemplateOptions{Value: "key-from-b", SecretPath: "/shared"}))
 
 		db, ok := tree["db"].(map[string]any)
 		Expect(ok).To(BeTrue())
-		Expect(db["DB_PORT"]).To(Equal(model.SecretTemplateOptions{Value: "1234", SecretPath: "/db"}))
+		Expect(db["DB_PORT"]).To(Equal(model.V1TemplateOptions{Value: "1234", SecretPath: "/db"}))
 	})
 
 	It("handles mixed root and nested secrets", func() {
@@ -111,14 +111,14 @@ var _ = Describe("BuildSecretTree", func() {
 
 		tree := v1.BuildSecretTree(ctx)
 
-		Expect(tree["AT_ROOT"]).To(Equal(model.SecretTemplateOptions{Value: "r", SecretPath: "/"}))
+		Expect(tree["AT_ROOT"]).To(Equal(model.V1TemplateOptions{Value: "r", SecretPath: "/"}))
 		app, ok := tree["app"].(map[string]any)
 		Expect(ok).To(BeTrue())
-		Expect(app["IN_FOLDER"]).To(Equal(model.SecretTemplateOptions{Value: "f", SecretPath: "/app"}))
+		Expect(app["IN_FOLDER"]).To(Equal(model.V1TemplateOptions{Value: "f", SecretPath: "/app"}))
 	})
 })
 
-var _ = Describe("RenderPerKeyTemplates without resolveSecretFromPath", func() {
+var _ = Describe("RenderPerKeyTemplates without getSecretByPath", func() {
 
 	rootCtx := v1.NewTemplateContext(nil, []api.Secret{
 		{SecretKey: "DB_HOST", SecretValue: "localhost", SecretPath: "/"},
@@ -129,6 +129,16 @@ var _ = Describe("RenderPerKeyTemplates without resolveSecretFromPath", func() {
 	It("resolves .Value accessor directly", func() {
 		tmpls := map[string]string{
 			"host": `{{ .DB_HOST.Value }}`,
+		}
+
+		data, err := v1.RenderPerKeyTemplates(tmpls, rootCtx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(data).To(HaveKeyWithValue("host", []byte("localhost")))
+	})
+
+	It("resolves value when .Value is not used", func() {
+		tmpls := map[string]string{
+			"host": `{{ .DB_HOST }}`,
 		}
 
 		data, err := v1.RenderPerKeyTemplates(tmpls, rootCtx)
@@ -157,7 +167,7 @@ var _ = Describe("RenderPerKeyTemplates without resolveSecretFromPath", func() {
 	})
 })
 
-var _ = Describe("RenderBulkTemplate without resolveSecretFromPath", func() {
+var _ = Describe("RenderBulkTemplate without getSecretByPath", func() {
 
 	rootCtx := v1.NewTemplateContext(nil, []api.Secret{
 		{SecretKey: "DB_HOST", SecretValue: "localhost", SecretPath: "/"},
@@ -185,11 +195,11 @@ var _ = Describe("RenderBulkTemplate without resolveSecretFromPath", func() {
 	})
 })
 
-var _ = Describe("RenderPerKeyTemplates with resolveSecretFromPath", func() {
+var _ = Describe("RenderPerKeyTemplates with getSecretByPath", func() {
 
-	It("resolves value via resolveSecretFromPath with nested path", func() {
+	It("resolves value via getSecretByPath with .Value accessor", func() {
 		tmpls := map[string]string{
-			"host": `{{ resolveSecretFromPath "folder.subfolder.DB_HOST.value" }}`,
+			"host": `{{ (getSecretByPath "folder/subfolder/DB_HOST").Value }}`,
 		}
 
 		data, err := v1.RenderPerKeyTemplates(tmpls, subfolderCtx)
@@ -197,9 +207,19 @@ var _ = Describe("RenderPerKeyTemplates with resolveSecretFromPath", func() {
 		Expect(data).To(HaveKeyWithValue("host", []byte("prod-db.example.com")))
 	})
 
-	It("resolves secretPath via resolveSecretFromPath", func() {
+	It("resolves value via getSecretByPath without accessor", func() {
 		tmpls := map[string]string{
-			"path": `{{ resolveSecretFromPath "folder.subfolder.DB_HOST.secretPath" }}`,
+			"host": `{{ getSecretByPath "folder/subfolder/DB_HOST" }}`,
+		}
+
+		data, err := v1.RenderPerKeyTemplates(tmpls, subfolderCtx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(data).To(HaveKeyWithValue("host", []byte("prod-db.example.com")))
+	})
+
+	It("resolves secretPath via getSecretByPath", func() {
+		tmpls := map[string]string{
+			"path": `{{ (getSecretByPath "folder/subfolder/DB_HOST").SecretPath }}`,
 		}
 
 		data, err := v1.RenderPerKeyTemplates(tmpls, subfolderCtx)
@@ -209,7 +229,7 @@ var _ = Describe("RenderPerKeyTemplates with resolveSecretFromPath", func() {
 
 	It("resolves secrets from different subfolders in the same template", func() {
 		tmpls := map[string]string{
-			"combined": `{{ resolveSecretFromPath "folder.subfolder.DB_HOST.value" }}:{{ resolveSecretFromPath "folder.subfolder.DB_PORT.value" }} key={{ resolveSecretFromPath "folder.other.API_KEY.value" }}`,
+			"combined": `{{ getSecretByPath "folder/subfolder/DB_HOST" }}:{{ getSecretByPath "folder/subfolder/DB_PORT" }} key={{ getSecretByPath "folder/other/API_KEY" }}`,
 		}
 
 		data, err := v1.RenderPerKeyTemplates(tmpls, subfolderCtx)
@@ -217,19 +237,9 @@ var _ = Describe("RenderPerKeyTemplates with resolveSecretFromPath", func() {
 		Expect(data).To(HaveKeyWithValue("combined", []byte("prod-db.example.com:5432 key=other-secret")))
 	})
 
-	It("returns error for unknown accessor", func() {
-		tmpls := map[string]string{
-			"bad": `{{ resolveSecretFromPath "folder.subfolder.DB_HOST.unknown" }}`,
-		}
-
-		_, err := v1.RenderPerKeyTemplates(tmpls, subfolderCtx)
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("unknown accessor"))
-	})
-
 	It("returns error for non-existent path segment", func() {
 		tmpls := map[string]string{
-			"bad": `{{ resolveSecretFromPath "missing.DB_HOST.value" }}`,
+			"bad": `{{ getSecretByPath "missing/DB_HOST" }}`,
 		}
 
 		_, err := v1.RenderPerKeyTemplates(tmpls, subfolderCtx)
@@ -237,11 +247,11 @@ var _ = Describe("RenderPerKeyTemplates with resolveSecretFromPath", func() {
 		Expect(err.Error()).To(ContainSubstring("not found"))
 	})
 
-	It("does not duplicate values when ranging over all secrets alongside resolveSecretFromPath", func() {
+	It("does not duplicate values when ranging over all secrets alongside getSecretByPath", func() {
 		tmpls := map[string]string{
-			"ref_host": `{{ resolveSecretFromPath "folder.subfolder.DB_HOST.value" }}`,
-			"ref_port": `{{ resolveSecretFromPath "folder.subfolder.DB_PORT.value" }}`,
-			"ref_key":  `{{ resolveSecretFromPath "folder.other.API_KEY.value" }}`,
+			"ref_host": `{{ getSecretByPath "folder/subfolder/DB_HOST" }}`,
+			"ref_port": `{{ getSecretByPath "folder/subfolder/DB_PORT" }}`,
+			"ref_key":  `{{ getSecretByPath "folder/other/API_KEY" }}`,
 		}
 
 		data, err := v1.RenderPerKeyTemplates(tmpls, subfolderCtx)
@@ -259,13 +269,13 @@ var _ = Describe("RenderPerKeyTemplates with resolveSecretFromPath", func() {
 				unique = append(unique, v)
 			}
 		}
-		Expect(unique).To(HaveLen(3), "each resolveSecretFromPath should resolve to a distinct value")
+		Expect(unique).To(HaveLen(3), "each getSecretByPath should resolve to a distinct value")
 	})
 
 	It("resolves duplicate secret keys from different paths", func() {
 		tmpls := map[string]string{
-			"subfolder_key": `{{ resolveSecretFromPath "folder.subfolder.API_KEY.value" }}`,
-			"other_key":     `{{ resolveSecretFromPath "folder.other.API_KEY.value" }}`,
+			"subfolder_key": `{{ getSecretByPath "folder/subfolder/API_KEY" }}`,
+			"other_key":     `{{ getSecretByPath "folder/other/API_KEY" }}`,
 		}
 
 		data, err := v1.RenderPerKeyTemplates(tmpls, subfolderCtx)
@@ -276,8 +286,8 @@ var _ = Describe("RenderPerKeyTemplates with resolveSecretFromPath", func() {
 
 	It("resolves secretPath of duplicate secret keys from different paths", func() {
 		tmpls := map[string]string{
-			"subfolder_path": `{{ resolveSecretFromPath "folder.subfolder.API_KEY.secretPath" }}`,
-			"other_path":     `{{ resolveSecretFromPath "folder.other.API_KEY.secretPath" }}`,
+			"subfolder_path": `{{ (getSecretByPath "folder/subfolder/API_KEY").SecretPath }}`,
+			"other_path":     `{{ (getSecretByPath "folder/other/API_KEY").SecretPath }}`,
 		}
 
 		data, err := v1.RenderPerKeyTemplates(tmpls, subfolderCtx)
@@ -287,26 +297,26 @@ var _ = Describe("RenderPerKeyTemplates with resolveSecretFromPath", func() {
 	})
 })
 
-var _ = Describe("RenderBulkTemplate with resolveSecretFromPath", func() {
+var _ = Describe("RenderBulkTemplate with getSecretByPath", func() {
 
 	It("returns error for non-existent path segment", func() {
-		tmpl := `bad: "{{ resolveSecretFromPath "missing.DB_HOST.value" }}"`
+		tmpl := `bad: "{{ getSecretByPath "missing/DB_HOST" }}"`
 
 		_, err := v1.RenderBulkTemplate(tmpl, subfolderCtx)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("not found"))
 	})
 
-	It("resolves value via resolveSecretFromPath", func() {
-		tmpl := `host: "{{ resolveSecretFromPath "folder.subfolder.DB_HOST.value" }}"`
+	It("resolves value via getSecretByPath", func() {
+		tmpl := `host: "{{ getSecretByPath "folder/subfolder/DB_HOST" }}"`
 
 		data, err := v1.RenderBulkTemplate(tmpl, subfolderCtx)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(data).To(HaveKeyWithValue("host", []byte("prod-db.example.com")))
 	})
 
-	It("resolves secretPath via resolveSecretFromPath", func() {
-		tmpl := `path: "{{ resolveSecretFromPath "folder.other.API_KEY.secretPath" }}"`
+	It("resolves secretPath via getSecretByPath", func() {
+		tmpl := `path: "{{ (getSecretByPath "folder/other/API_KEY").SecretPath }}"`
 
 		data, err := v1.RenderBulkTemplate(tmpl, subfolderCtx)
 		Expect(err).NotTo(HaveOccurred())
@@ -314,8 +324,8 @@ var _ = Describe("RenderBulkTemplate with resolveSecretFromPath", func() {
 	})
 
 	It("resolves multiple secrets from different subfolders", func() {
-		tmpl := `dsn: "{{ resolveSecretFromPath "folder.subfolder.DB_HOST.value" }}:{{ resolveSecretFromPath "folder.subfolder.DB_PORT.value" }}"
-api_key: "{{ resolveSecretFromPath "folder.other.API_KEY.value" }}"`
+		tmpl := `dsn: "{{ getSecretByPath "folder/subfolder/DB_HOST" }}:{{ getSecretByPath "folder/subfolder/DB_PORT" }}"
+api_key: "{{ getSecretByPath "folder/other/API_KEY" }}"`
 
 		data, err := v1.RenderBulkTemplate(tmpl, subfolderCtx)
 		Expect(err).NotTo(HaveOccurred())
@@ -324,10 +334,10 @@ api_key: "{{ resolveSecretFromPath "folder.other.API_KEY.value" }}"`
 		Expect(data).To(HaveKeyWithValue("api_key", []byte("other-secret")))
 	})
 
-	It("does not duplicate values when rendering all secrets via resolveSecretFromPath", func() {
-		tmpl := `host: "{{ resolveSecretFromPath "folder.subfolder.DB_HOST.value" }}"
-port: "{{ resolveSecretFromPath "folder.subfolder.DB_PORT.value" }}"
-key: "{{ resolveSecretFromPath "folder.other.API_KEY.value" }}"`
+	It("does not duplicate values when rendering all secrets via getSecretByPath", func() {
+		tmpl := `host: "{{ getSecretByPath "folder/subfolder/DB_HOST" }}"
+port: "{{ getSecretByPath "folder/subfolder/DB_PORT" }}"
+key: "{{ getSecretByPath "folder/other/API_KEY" }}"`
 
 		data, err := v1.RenderBulkTemplate(tmpl, subfolderCtx)
 		Expect(err).NotTo(HaveOccurred())
@@ -344,12 +354,12 @@ key: "{{ resolveSecretFromPath "folder.other.API_KEY.value" }}"`
 				unique = append(unique, v)
 			}
 		}
-		Expect(unique).To(HaveLen(3), "each resolveSecretFromPath should resolve to a distinct value")
+		Expect(unique).To(HaveLen(3), "each getSecretByPath should resolve to a distinct value")
 	})
 
 	It("resolves duplicate secret keys from different paths", func() {
-		tmpl := `subfolder_key: "{{ resolveSecretFromPath "folder.subfolder.API_KEY.value" }}"
-other_key: "{{ resolveSecretFromPath "folder.other.API_KEY.value" }}"`
+		tmpl := `subfolder_key: "{{ getSecretByPath "folder/subfolder/API_KEY" }}"
+other_key: "{{ getSecretByPath "folder/other/API_KEY" }}"`
 
 		data, err := v1.RenderBulkTemplate(tmpl, subfolderCtx)
 		Expect(err).NotTo(HaveOccurred())
@@ -358,8 +368,8 @@ other_key: "{{ resolveSecretFromPath "folder.other.API_KEY.value" }}"`
 	})
 
 	It("resolves secretPath of duplicate secret keys from different paths", func() {
-		tmpl := `subfolder_path: "{{ resolveSecretFromPath "folder.subfolder.API_KEY.secretPath" }}"
-other_path: "{{ resolveSecretFromPath "folder.other.API_KEY.secretPath" }}"`
+		tmpl := `subfolder_path: "{{ (getSecretByPath "folder/subfolder/API_KEY").SecretPath }}"
+other_path: "{{ (getSecretByPath "folder/other/API_KEY").SecretPath }}"`
 
 		data, err := v1.RenderBulkTemplate(tmpl, subfolderCtx)
 		Expect(err).NotTo(HaveOccurred())

--- a/internal/template/v1/template_test.go
+++ b/internal/template/v1/template_test.go
@@ -35,17 +35,17 @@ var _ = Describe("BuildSecretTree", func() {
 
 		tree := v1.BuildSecretTree(ctx)
 
-		folder, ok := tree["folder"].(map[string]any)
-		Expect(ok).To(BeTrue())
+		folder := tree.Children["folder"]
+		Expect(folder).NotTo(BeNil())
 
-		subfolder, ok := folder["subfolder"].(map[string]any)
-		Expect(ok).To(BeTrue())
-		Expect(subfolder["SECRET_1"]).To(Equal(model.V1TemplateOptions{Value: "val1", SecretPath: "/folder/subfolder"}))
-		Expect(subfolder["SECRET_2"]).To(Equal(model.V1TemplateOptions{Value: "val2", SecretPath: "/folder/subfolder"}))
+		subfolder := folder.Children["subfolder"]
+		Expect(subfolder).NotTo(BeNil())
+		Expect(subfolder.Children["SECRET_1"].Secret).To(HaveValue(Equal(model.V1TemplateOptions{Value: "val1", SecretPath: "/folder/subfolder"})))
+		Expect(subfolder.Children["SECRET_2"].Secret).To(HaveValue(Equal(model.V1TemplateOptions{Value: "val2", SecretPath: "/folder/subfolder"})))
 
-		another, ok := folder["another"].(map[string]any)
-		Expect(ok).To(BeTrue())
-		Expect(another["SECRET_3"]).To(Equal(model.V1TemplateOptions{Value: "val3", SecretPath: "/folder/another"}))
+		another := folder.Children["another"]
+		Expect(another).NotTo(BeNil())
+		Expect(another.Children["SECRET_3"].Secret).To(HaveValue(Equal(model.V1TemplateOptions{Value: "val3", SecretPath: "/folder/another"})))
 	})
 
 	It("places secrets at the root path", func() {
@@ -54,13 +54,13 @@ var _ = Describe("BuildSecretTree", func() {
 		}, nil)
 
 		tree := v1.BuildSecretTree(ctx)
-		Expect(tree["ROOT_SECRET"]).To(Equal(model.V1TemplateOptions{Value: "root-val", SecretPath: "/"}))
+		Expect(tree.Children["ROOT_SECRET"].Secret).To(HaveValue(Equal(model.V1TemplateOptions{Value: "root-val", SecretPath: "/"})))
 	})
 
 	It("returns an empty tree for empty context", func() {
 		ctx := v1.NewTemplateContext(nil, nil)
 		tree := v1.BuildSecretTree(ctx)
-		Expect(tree).To(BeEmpty())
+		Expect(tree.Children).To(BeNil())
 	})
 
 	It("handles deeply nested paths", func() {
@@ -70,15 +70,15 @@ var _ = Describe("BuildSecretTree", func() {
 
 		tree := v1.BuildSecretTree(ctx)
 
-		a, ok := tree["a"].(map[string]any)
-		Expect(ok).To(BeTrue())
-		b, ok := a["b"].(map[string]any)
-		Expect(ok).To(BeTrue())
-		c, ok := b["c"].(map[string]any)
-		Expect(ok).To(BeTrue())
-		d, ok := c["d"].(map[string]any)
-		Expect(ok).To(BeTrue())
-		Expect(d["DEEP"]).To(Equal(model.V1TemplateOptions{Value: "deep-val", SecretPath: "/a/b/c/d"}))
+		a := tree.Children["a"]
+		Expect(a).NotTo(BeNil())
+		b := a.Children["b"]
+		Expect(b).NotTo(BeNil())
+		c := b.Children["c"]
+		Expect(c).NotTo(BeNil())
+		d := c.Children["d"]
+		Expect(d).NotTo(BeNil())
+		Expect(d.Children["DEEP"].Secret).To(HaveValue(Equal(model.V1TemplateOptions{Value: "deep-val", SecretPath: "/a/b/c/d"})))
 	})
 
 	It("keeps first occurrence when duplicate keys exist at the same path", func() {
@@ -92,15 +92,15 @@ var _ = Describe("BuildSecretTree", func() {
 
 		tree := v1.BuildSecretTree(ctx)
 
-		shared, ok := tree["shared"].(map[string]any)
-		Expect(ok).To(BeTrue())
-		Expect(shared["DB_HOST"]).To(Equal(model.V1TemplateOptions{Value: "project-a-host", SecretPath: "/shared"}))
-		Expect(shared["DB_PORT"]).To(Equal(model.V1TemplateOptions{Value: "5432", SecretPath: "/shared"}))
-		Expect(shared["API_KEY"]).To(Equal(model.V1TemplateOptions{Value: "key-from-b", SecretPath: "/shared"}))
+		shared := tree.Children["shared"]
+		Expect(shared).NotTo(BeNil())
+		Expect(shared.Children["DB_HOST"].Secret).To(HaveValue(Equal(model.V1TemplateOptions{Value: "project-a-host", SecretPath: "/shared"})))
+		Expect(shared.Children["DB_PORT"].Secret).To(HaveValue(Equal(model.V1TemplateOptions{Value: "5432", SecretPath: "/shared"})))
+		Expect(shared.Children["API_KEY"].Secret).To(HaveValue(Equal(model.V1TemplateOptions{Value: "key-from-b", SecretPath: "/shared"})))
 
-		db, ok := tree["db"].(map[string]any)
-		Expect(ok).To(BeTrue())
-		Expect(db["DB_PORT"]).To(Equal(model.V1TemplateOptions{Value: "1234", SecretPath: "/db"}))
+		db := tree.Children["db"]
+		Expect(db).NotTo(BeNil())
+		Expect(db.Children["DB_PORT"].Secret).To(HaveValue(Equal(model.V1TemplateOptions{Value: "1234", SecretPath: "/db"})))
 	})
 
 	It("handles mixed root and nested secrets", func() {
@@ -111,10 +111,24 @@ var _ = Describe("BuildSecretTree", func() {
 
 		tree := v1.BuildSecretTree(ctx)
 
-		Expect(tree["AT_ROOT"]).To(Equal(model.V1TemplateOptions{Value: "r", SecretPath: "/"}))
-		app, ok := tree["app"].(map[string]any)
-		Expect(ok).To(BeTrue())
-		Expect(app["IN_FOLDER"]).To(Equal(model.V1TemplateOptions{Value: "f", SecretPath: "/app"}))
+		Expect(tree.Children["AT_ROOT"].Secret).To(HaveValue(Equal(model.V1TemplateOptions{Value: "r", SecretPath: "/"})))
+		app := tree.Children["app"]
+		Expect(app).NotTo(BeNil())
+		Expect(app.Children["IN_FOLDER"].Secret).To(HaveValue(Equal(model.V1TemplateOptions{Value: "f", SecretPath: "/app"})))
+	})
+
+	It("allows a secret key and folder segment with the same name", func() {
+		ctx := v1.NewTemplateContext([]api.Secret{
+			{SecretKey: "db", SecretValue: "some-value", SecretPath: "/"},
+			{SecretKey: "PASSWORD", SecretValue: "secret", SecretPath: "/db"},
+		}, nil)
+
+		tree := v1.BuildSecretTree(ctx)
+
+		dbNode := tree.Children["db"]
+		Expect(dbNode).NotTo(BeNil())
+		Expect(dbNode.Secret).To(HaveValue(Equal(model.V1TemplateOptions{Value: "some-value", SecretPath: "/"})))
+		Expect(dbNode.Children["PASSWORD"].Secret).To(HaveValue(Equal(model.V1TemplateOptions{Value: "secret", SecretPath: "/db"})))
 	})
 })
 

--- a/internal/template/v1/template_test.go
+++ b/internal/template/v1/template_test.go
@@ -118,7 +118,7 @@ var _ = Describe("BuildSecretTree", func() {
 	})
 })
 
-var _ = Describe("RenderPerKeyTemplates without getSecretByPath", func() {
+var _ = Describe("RenderPerKeyTemplates without secretFrom", func() {
 
 	rootCtx := v1.NewTemplateContext(nil, []api.Secret{
 		{SecretKey: "DB_HOST", SecretValue: "localhost", SecretPath: "/"},
@@ -167,7 +167,7 @@ var _ = Describe("RenderPerKeyTemplates without getSecretByPath", func() {
 	})
 })
 
-var _ = Describe("RenderBulkTemplate without getSecretByPath", func() {
+var _ = Describe("RenderBulkTemplate without secretFrom", func() {
 
 	rootCtx := v1.NewTemplateContext(nil, []api.Secret{
 		{SecretKey: "DB_HOST", SecretValue: "localhost", SecretPath: "/"},
@@ -195,11 +195,11 @@ var _ = Describe("RenderBulkTemplate without getSecretByPath", func() {
 	})
 })
 
-var _ = Describe("RenderPerKeyTemplates with getSecretByPath", func() {
+var _ = Describe("RenderPerKeyTemplates with secretFrom", func() {
 
-	It("resolves value via getSecretByPath with .Value accessor", func() {
+	It("resolves value via secretFrom with .Value accessor", func() {
 		tmpls := map[string]string{
-			"host": `{{ (getSecretByPath "folder/subfolder/DB_HOST").Value }}`,
+			"host": `{{ (secretFrom "/folder/subfolder" "DB_HOST").Value }}`,
 		}
 
 		data, err := v1.RenderPerKeyTemplates(tmpls, subfolderCtx)
@@ -207,9 +207,9 @@ var _ = Describe("RenderPerKeyTemplates with getSecretByPath", func() {
 		Expect(data).To(HaveKeyWithValue("host", []byte("prod-db.example.com")))
 	})
 
-	It("resolves value via getSecretByPath without accessor", func() {
+	It("resolves value via secretFrom without accessor", func() {
 		tmpls := map[string]string{
-			"host": `{{ getSecretByPath "folder/subfolder/DB_HOST" }}`,
+			"host": `{{ secretFrom "/folder/subfolder" "DB_HOST" }}`,
 		}
 
 		data, err := v1.RenderPerKeyTemplates(tmpls, subfolderCtx)
@@ -217,9 +217,27 @@ var _ = Describe("RenderPerKeyTemplates with getSecretByPath", func() {
 		Expect(data).To(HaveKeyWithValue("host", []byte("prod-db.example.com")))
 	})
 
-	It("resolves secretPath via getSecretByPath", func() {
+	It("resolves value via secretFrom with single argument (name only)", func() {
+		rootCtx := v1.NewTemplateContext(
+			[]api.Secret{
+				{SecretKey: "MY_SECRET", SecretValue: "root-val", SecretPath: "/"},
+			},
+			[]api.Secret{
+				{SecretKey: "MY_SECRET", SecretValue: "root-val", SecretPath: "/"},
+			},
+		)
 		tmpls := map[string]string{
-			"path": `{{ (getSecretByPath "folder/subfolder/DB_HOST").SecretPath }}`,
+			"secret": `{{ secretFrom "MY_SECRET" }}`,
+		}
+
+		data, err := v1.RenderPerKeyTemplates(tmpls, rootCtx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(data).To(HaveKeyWithValue("secret", []byte("root-val")))
+	})
+
+	It("resolves secretPath via secretFrom", func() {
+		tmpls := map[string]string{
+			"path": `{{ (secretFrom "/folder/subfolder" "DB_HOST").SecretPath }}`,
 		}
 
 		data, err := v1.RenderPerKeyTemplates(tmpls, subfolderCtx)
@@ -229,7 +247,7 @@ var _ = Describe("RenderPerKeyTemplates with getSecretByPath", func() {
 
 	It("resolves secrets from different subfolders in the same template", func() {
 		tmpls := map[string]string{
-			"combined": `{{ getSecretByPath "folder/subfolder/DB_HOST" }}:{{ getSecretByPath "folder/subfolder/DB_PORT" }} key={{ getSecretByPath "folder/other/API_KEY" }}`,
+			"combined": `{{ secretFrom "/folder/subfolder" "DB_HOST" }}:{{ secretFrom "/folder/subfolder" "DB_PORT" }} key={{ secretFrom "/folder/other" "API_KEY" }}`,
 		}
 
 		data, err := v1.RenderPerKeyTemplates(tmpls, subfolderCtx)
@@ -239,7 +257,7 @@ var _ = Describe("RenderPerKeyTemplates with getSecretByPath", func() {
 
 	It("returns error for non-existent path segment", func() {
 		tmpls := map[string]string{
-			"bad": `{{ getSecretByPath "missing/DB_HOST" }}`,
+			"bad": `{{ secretFrom "/missing" "DB_HOST" }}`,
 		}
 
 		_, err := v1.RenderPerKeyTemplates(tmpls, subfolderCtx)
@@ -247,11 +265,21 @@ var _ = Describe("RenderPerKeyTemplates with getSecretByPath", func() {
 		Expect(err.Error()).To(ContainSubstring("not found"))
 	})
 
-	It("does not duplicate values when ranging over all secrets alongside getSecretByPath", func() {
+	It("returns error for non-existent secret name", func() {
 		tmpls := map[string]string{
-			"ref_host": `{{ getSecretByPath "folder/subfolder/DB_HOST" }}`,
-			"ref_port": `{{ getSecretByPath "folder/subfolder/DB_PORT" }}`,
-			"ref_key":  `{{ getSecretByPath "folder/other/API_KEY" }}`,
+			"bad": `{{ secretFrom "/folder/subfolder" "NOPE" }}`,
+		}
+
+		_, err := v1.RenderPerKeyTemplates(tmpls, subfolderCtx)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("not found"))
+	})
+
+	It("does not duplicate values when ranging over all secrets alongside secretFrom", func() {
+		tmpls := map[string]string{
+			"ref_host": `{{ secretFrom "/folder/subfolder" "DB_HOST" }}`,
+			"ref_port": `{{ secretFrom "/folder/subfolder" "DB_PORT" }}`,
+			"ref_key":  `{{ secretFrom "/folder/other" "API_KEY" }}`,
 		}
 
 		data, err := v1.RenderPerKeyTemplates(tmpls, subfolderCtx)
@@ -269,13 +297,13 @@ var _ = Describe("RenderPerKeyTemplates with getSecretByPath", func() {
 				unique = append(unique, v)
 			}
 		}
-		Expect(unique).To(HaveLen(3), "each getSecretByPath should resolve to a distinct value")
+		Expect(unique).To(HaveLen(3), "each secretFrom should resolve to a distinct value")
 	})
 
 	It("resolves duplicate secret keys from different paths", func() {
 		tmpls := map[string]string{
-			"subfolder_key": `{{ getSecretByPath "folder/subfolder/API_KEY" }}`,
-			"other_key":     `{{ getSecretByPath "folder/other/API_KEY" }}`,
+			"subfolder_key": `{{ secretFrom "/folder/subfolder" "API_KEY" }}`,
+			"other_key":     `{{ secretFrom "/folder/other" "API_KEY" }}`,
 		}
 
 		data, err := v1.RenderPerKeyTemplates(tmpls, subfolderCtx)
@@ -286,8 +314,8 @@ var _ = Describe("RenderPerKeyTemplates with getSecretByPath", func() {
 
 	It("resolves secretPath of duplicate secret keys from different paths", func() {
 		tmpls := map[string]string{
-			"subfolder_path": `{{ (getSecretByPath "folder/subfolder/API_KEY").SecretPath }}`,
-			"other_path":     `{{ (getSecretByPath "folder/other/API_KEY").SecretPath }}`,
+			"subfolder_path": `{{ (secretFrom "/folder/subfolder" "API_KEY").SecretPath }}`,
+			"other_path":     `{{ (secretFrom "/folder/other" "API_KEY").SecretPath }}`,
 		}
 
 		data, err := v1.RenderPerKeyTemplates(tmpls, subfolderCtx)
@@ -297,26 +325,26 @@ var _ = Describe("RenderPerKeyTemplates with getSecretByPath", func() {
 	})
 })
 
-var _ = Describe("RenderBulkTemplate with getSecretByPath", func() {
+var _ = Describe("RenderBulkTemplate with secretFrom", func() {
 
 	It("returns error for non-existent path segment", func() {
-		tmpl := `bad: "{{ getSecretByPath "missing/DB_HOST" }}"`
+		tmpl := `bad: "{{ secretFrom "/missing" "DB_HOST" }}"`
 
 		_, err := v1.RenderBulkTemplate(tmpl, subfolderCtx)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("not found"))
 	})
 
-	It("resolves value via getSecretByPath", func() {
-		tmpl := `host: "{{ getSecretByPath "folder/subfolder/DB_HOST" }}"`
+	It("resolves value via secretFrom", func() {
+		tmpl := `host: "{{ secretFrom "/folder/subfolder" "DB_HOST" }}"`
 
 		data, err := v1.RenderBulkTemplate(tmpl, subfolderCtx)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(data).To(HaveKeyWithValue("host", []byte("prod-db.example.com")))
 	})
 
-	It("resolves secretPath via getSecretByPath", func() {
-		tmpl := `path: "{{ (getSecretByPath "folder/other/API_KEY").SecretPath }}"`
+	It("resolves secretPath via secretFrom", func() {
+		tmpl := `path: "{{ (secretFrom "/folder/other" "API_KEY").SecretPath }}"`
 
 		data, err := v1.RenderBulkTemplate(tmpl, subfolderCtx)
 		Expect(err).NotTo(HaveOccurred())
@@ -324,8 +352,8 @@ var _ = Describe("RenderBulkTemplate with getSecretByPath", func() {
 	})
 
 	It("resolves multiple secrets from different subfolders", func() {
-		tmpl := `dsn: "{{ getSecretByPath "folder/subfolder/DB_HOST" }}:{{ getSecretByPath "folder/subfolder/DB_PORT" }}"
-api_key: "{{ getSecretByPath "folder/other/API_KEY" }}"`
+		tmpl := `dsn: "{{ secretFrom "/folder/subfolder" "DB_HOST" }}:{{ secretFrom "/folder/subfolder" "DB_PORT" }}"
+api_key: "{{ secretFrom "/folder/other" "API_KEY" }}"`
 
 		data, err := v1.RenderBulkTemplate(tmpl, subfolderCtx)
 		Expect(err).NotTo(HaveOccurred())
@@ -334,10 +362,10 @@ api_key: "{{ getSecretByPath "folder/other/API_KEY" }}"`
 		Expect(data).To(HaveKeyWithValue("api_key", []byte("other-secret")))
 	})
 
-	It("does not duplicate values when rendering all secrets via getSecretByPath", func() {
-		tmpl := `host: "{{ getSecretByPath "folder/subfolder/DB_HOST" }}"
-port: "{{ getSecretByPath "folder/subfolder/DB_PORT" }}"
-key: "{{ getSecretByPath "folder/other/API_KEY" }}"`
+	It("does not duplicate values when rendering all secrets via secretFrom", func() {
+		tmpl := `host: "{{ secretFrom "/folder/subfolder" "DB_HOST" }}"
+port: "{{ secretFrom "/folder/subfolder" "DB_PORT" }}"
+key: "{{ secretFrom "/folder/other" "API_KEY" }}"`
 
 		data, err := v1.RenderBulkTemplate(tmpl, subfolderCtx)
 		Expect(err).NotTo(HaveOccurred())
@@ -354,12 +382,12 @@ key: "{{ getSecretByPath "folder/other/API_KEY" }}"`
 				unique = append(unique, v)
 			}
 		}
-		Expect(unique).To(HaveLen(3), "each getSecretByPath should resolve to a distinct value")
+		Expect(unique).To(HaveLen(3), "each secretFrom should resolve to a distinct value")
 	})
 
 	It("resolves duplicate secret keys from different paths", func() {
-		tmpl := `subfolder_key: "{{ getSecretByPath "folder/subfolder/API_KEY" }}"
-other_key: "{{ getSecretByPath "folder/other/API_KEY" }}"`
+		tmpl := `subfolder_key: "{{ secretFrom "/folder/subfolder" "API_KEY" }}"
+other_key: "{{ secretFrom "/folder/other" "API_KEY" }}"`
 
 		data, err := v1.RenderBulkTemplate(tmpl, subfolderCtx)
 		Expect(err).NotTo(HaveOccurred())
@@ -368,8 +396,8 @@ other_key: "{{ getSecretByPath "folder/other/API_KEY" }}"`
 	})
 
 	It("resolves secretPath of duplicate secret keys from different paths", func() {
-		tmpl := `subfolder_path: "{{ (getSecretByPath "folder/subfolder/API_KEY").SecretPath }}"
-other_path: "{{ (getSecretByPath "folder/other/API_KEY").SecretPath }}"`
+		tmpl := `subfolder_path: "{{ (secretFrom "/folder/subfolder" "API_KEY").SecretPath }}"
+other_path: "{{ (secretFrom "/folder/other" "API_KEY").SecretPath }}"`
 
 		data, err := v1.RenderBulkTemplate(tmpl, subfolderCtx)
 		Expect(err).NotTo(HaveOccurred())

--- a/internal/template/v1/template_test.go
+++ b/internal/template/v1/template_test.go
@@ -1,0 +1,293 @@
+package v1_test
+
+import (
+	"sort"
+
+	"github.com/Infisical/infisical/k8-operator/internal/model"
+	v1 "github.com/Infisical/infisical/k8-operator/internal/template/v1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var subfolderSecrets = map[string]model.SecretTemplateOptions{
+	"DB_HOST": {Value: "prod-db.example.com", SecretPath: "/folder/subfolder"},
+	"DB_PORT": {Value: "5432", SecretPath: "/folder/subfolder"},
+	"API_KEY": {Value: "sk-secret-123", SecretPath: "/folder/other"},
+}
+
+var _ = Describe("BuildSecretTree", func() {
+
+	It("places secrets in nested subfolders", func() {
+		ctx := map[string]model.SecretTemplateOptions{
+			"SECRET_1": {Value: "val1", SecretPath: "/folder/subfolder"},
+			"SECRET_2": {Value: "val2", SecretPath: "/folder/subfolder"},
+			"SECRET_3": {Value: "val3", SecretPath: "/folder/another"},
+		}
+
+		tree := v1.BuildSecretTree(ctx)
+
+		folder, ok := tree["folder"].(map[string]any)
+		Expect(ok).To(BeTrue())
+
+		subfolder, ok := folder["subfolder"].(map[string]any)
+		Expect(ok).To(BeTrue())
+		Expect(subfolder["SECRET_1"]).To(Equal(model.SecretTemplateOptions{Value: "val1", SecretPath: "/folder/subfolder"}))
+		Expect(subfolder["SECRET_2"]).To(Equal(model.SecretTemplateOptions{Value: "val2", SecretPath: "/folder/subfolder"}))
+
+		another, ok := folder["another"].(map[string]any)
+		Expect(ok).To(BeTrue())
+		Expect(another["SECRET_3"]).To(Equal(model.SecretTemplateOptions{Value: "val3", SecretPath: "/folder/another"}))
+	})
+
+	It("places secrets at the root path", func() {
+		ctx := map[string]model.SecretTemplateOptions{
+			"ROOT_SECRET": {Value: "root-val", SecretPath: "/"},
+		}
+
+		tree := v1.BuildSecretTree(ctx)
+		Expect(tree["ROOT_SECRET"]).To(Equal(model.SecretTemplateOptions{Value: "root-val", SecretPath: "/"}))
+	})
+
+	It("returns an empty tree for empty context", func() {
+		tree := v1.BuildSecretTree(map[string]model.SecretTemplateOptions{})
+		Expect(tree).To(BeEmpty())
+	})
+
+	It("handles deeply nested paths", func() {
+		ctx := map[string]model.SecretTemplateOptions{
+			"DEEP": {Value: "deep-val", SecretPath: "/a/b/c/d"},
+		}
+
+		tree := v1.BuildSecretTree(ctx)
+
+		a, ok := tree["a"].(map[string]any)
+		Expect(ok).To(BeTrue())
+		b, ok := a["b"].(map[string]any)
+		Expect(ok).To(BeTrue())
+		c, ok := b["c"].(map[string]any)
+		Expect(ok).To(BeTrue())
+		d, ok := c["d"].(map[string]any)
+		Expect(ok).To(BeTrue())
+		Expect(d["DEEP"]).To(Equal(model.SecretTemplateOptions{Value: "deep-val", SecretPath: "/a/b/c/d"}))
+	})
+
+	It("handles mixed root and nested secrets", func() {
+		ctx := map[string]model.SecretTemplateOptions{
+			"AT_ROOT":   {Value: "r", SecretPath: "/"},
+			"IN_FOLDER": {Value: "f", SecretPath: "/app"},
+		}
+
+		tree := v1.BuildSecretTree(ctx)
+
+		Expect(tree["AT_ROOT"]).To(Equal(model.SecretTemplateOptions{Value: "r", SecretPath: "/"}))
+		app, ok := tree["app"].(map[string]any)
+		Expect(ok).To(BeTrue())
+		Expect(app["IN_FOLDER"]).To(Equal(model.SecretTemplateOptions{Value: "f", SecretPath: "/app"}))
+	})
+})
+
+var _ = Describe("RenderPerKeyTemplates without secretRef", func() {
+
+	rootSecrets := map[string]model.SecretTemplateOptions{
+		"DB_HOST": {Value: "localhost", SecretPath: "/"},
+		"DB_PORT": {Value: "5432", SecretPath: "/"},
+		"DB_NAME": {Value: "mydb", SecretPath: "/"},
+	}
+
+	It("resolves .Value accessor directly", func() {
+		tmpls := map[string]string{
+			"host": `{{ .DB_HOST.Value }}`,
+		}
+
+		data, err := v1.RenderPerKeyTemplates(tmpls, rootSecrets)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(data).To(HaveKeyWithValue("host", []byte("localhost")))
+	})
+
+	It("resolves .SecretPath accessor directly", func() {
+		tmpls := map[string]string{
+			"path": `{{ .DB_HOST.SecretPath }}`,
+		}
+
+		data, err := v1.RenderPerKeyTemplates(tmpls, rootSecrets)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(data).To(HaveKeyWithValue("path", []byte("/")))
+	})
+
+	It("combines multiple secrets in a single template key", func() {
+		tmpls := map[string]string{
+			"dsn": `postgresql://user:pass@{{ .DB_HOST.Value }}:{{ .DB_PORT.Value }}/{{ .DB_NAME.Value }}`,
+		}
+
+		data, err := v1.RenderPerKeyTemplates(tmpls, rootSecrets)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(data).To(HaveKeyWithValue("dsn", []byte("postgresql://user:pass@localhost:5432/mydb")))
+	})
+})
+
+var _ = Describe("RenderBulkTemplate without secretRef", func() {
+
+	rootSecrets := map[string]model.SecretTemplateOptions{
+		"DB_HOST": {Value: "localhost", SecretPath: "/"},
+		"DB_PORT": {Value: "5432", SecretPath: "/"},
+	}
+
+	It("resolves .Value accessor directly", func() {
+		tmpl := `host: "{{ .DB_HOST.Value }}"`
+
+		data, err := v1.RenderBulkTemplate(tmpl, rootSecrets)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(data).To(HaveKeyWithValue("host", []byte("localhost")))
+	})
+
+	It("renders a range over all secrets", func() {
+		tmpl := `{{- range $key, $secret := . }}
+{{ $key }}: "{{ $secret.Value }}"
+{{- end }}`
+
+		data, err := v1.RenderBulkTemplate(tmpl, rootSecrets)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(data).To(HaveLen(2))
+		Expect(data).To(HaveKeyWithValue("DB_HOST", []byte("localhost")))
+		Expect(data).To(HaveKeyWithValue("DB_PORT", []byte("5432")))
+	})
+})
+
+var _ = Describe("RenderPerKeyTemplates with secretRef", func() {
+
+	It("resolves value via secretRef with nested path", func() {
+		tmpls := map[string]string{
+			"host": `{{ secretRef "folder.subfolder.DB_HOST.value" }}`,
+		}
+
+		data, err := v1.RenderPerKeyTemplates(tmpls, subfolderSecrets)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(data).To(HaveKeyWithValue("host", []byte("prod-db.example.com")))
+	})
+
+	It("resolves secretPath via secretRef", func() {
+		tmpls := map[string]string{
+			"path": `{{ secretRef "folder.subfolder.DB_HOST.secretPath" }}`,
+		}
+
+		data, err := v1.RenderPerKeyTemplates(tmpls, subfolderSecrets)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(data).To(HaveKeyWithValue("path", []byte("/folder/subfolder")))
+	})
+
+	It("resolves secrets from different subfolders in the same template", func() {
+		tmpls := map[string]string{
+			"combined": `{{ secretRef "folder.subfolder.DB_HOST.value" }}:{{ secretRef "folder.subfolder.DB_PORT.value" }} key={{ secretRef "folder.other.API_KEY.value" }}`,
+		}
+
+		data, err := v1.RenderPerKeyTemplates(tmpls, subfolderSecrets)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(data).To(HaveKeyWithValue("combined", []byte("prod-db.example.com:5432 key=sk-secret-123")))
+	})
+
+	It("returns error for unknown accessor", func() {
+		tmpls := map[string]string{
+			"bad": `{{ secretRef "folder.subfolder.DB_HOST.unknown" }}`,
+		}
+
+		_, err := v1.RenderPerKeyTemplates(tmpls, subfolderSecrets)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("unknown accessor"))
+	})
+
+	It("returns error for non-existent path segment", func() {
+		tmpls := map[string]string{
+			"bad": `{{ secretRef "missing.DB_HOST.value" }}`,
+		}
+
+		_, err := v1.RenderPerKeyTemplates(tmpls, subfolderSecrets)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("not found"))
+	})
+
+	It("does not duplicate values when ranging over all secrets alongside secretRef", func() {
+		tmpls := map[string]string{
+			"ref_host": `{{ secretRef "folder.subfolder.DB_HOST.value" }}`,
+			"ref_port": `{{ secretRef "folder.subfolder.DB_PORT.value" }}`,
+			"ref_key":  `{{ secretRef "folder.other.API_KEY.value" }}`,
+		}
+
+		data, err := v1.RenderPerKeyTemplates(tmpls, subfolderSecrets)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(data).To(HaveLen(3))
+
+		values := make([]string, 0, len(data))
+		for _, v := range data {
+			values = append(values, string(v))
+		}
+		sort.Strings(values)
+		unique := make([]string, 0, len(values))
+		for i, v := range values {
+			if i == 0 || v != values[i-1] {
+				unique = append(unique, v)
+			}
+		}
+		Expect(unique).To(HaveLen(3), "each secretRef should resolve to a distinct value")
+	})
+})
+
+var _ = Describe("RenderBulkTemplate with secretRef", func() {
+
+	It("returns error for non-existent path segment", func() {
+		tmpl := `bad: "{{ secretRef "missing.DB_HOST.value" }}"`
+
+		_, err := v1.RenderBulkTemplate(tmpl, subfolderSecrets)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("not found"))
+	})
+
+	It("resolves value via secretRef", func() {
+		tmpl := `host: "{{ secretRef "folder.subfolder.DB_HOST.value" }}"`
+
+		data, err := v1.RenderBulkTemplate(tmpl, subfolderSecrets)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(data).To(HaveKeyWithValue("host", []byte("prod-db.example.com")))
+	})
+
+	It("resolves secretPath via secretRef", func() {
+		tmpl := `path: "{{ secretRef "folder.other.API_KEY.secretPath" }}"`
+
+		data, err := v1.RenderBulkTemplate(tmpl, subfolderSecrets)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(data).To(HaveKeyWithValue("path", []byte("/folder/other")))
+	})
+
+	It("resolves multiple secrets from different subfolders", func() {
+		tmpl := `dsn: "{{ secretRef "folder.subfolder.DB_HOST.value" }}:{{ secretRef "folder.subfolder.DB_PORT.value" }}"
+api_key: "{{ secretRef "folder.other.API_KEY.value" }}"`
+
+		data, err := v1.RenderBulkTemplate(tmpl, subfolderSecrets)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(data).To(HaveLen(2))
+		Expect(data).To(HaveKeyWithValue("dsn", []byte("prod-db.example.com:5432")))
+		Expect(data).To(HaveKeyWithValue("api_key", []byte("sk-secret-123")))
+	})
+
+	It("does not duplicate values when rendering all secrets via secretRef", func() {
+		tmpl := `host: "{{ secretRef "folder.subfolder.DB_HOST.value" }}"
+port: "{{ secretRef "folder.subfolder.DB_PORT.value" }}"
+key: "{{ secretRef "folder.other.API_KEY.value" }}"`
+
+		data, err := v1.RenderBulkTemplate(tmpl, subfolderSecrets)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(data).To(HaveLen(3))
+
+		values := make([]string, 0, len(data))
+		for _, v := range data {
+			values = append(values, string(v))
+		}
+		sort.Strings(values)
+		unique := make([]string, 0, len(values))
+		for i, v := range values {
+			if i == 0 || v != values[i-1] {
+				unique = append(unique, v)
+			}
+		}
+		Expect(unique).To(HaveLen(3), "each secretRef should resolve to a distinct value")
+	})
+})

--- a/internal/template/v1/template_test.go
+++ b/internal/template/v1/template_test.go
@@ -217,7 +217,7 @@ var _ = Describe("RenderPerKeyTemplates with secretFrom", func() {
 		Expect(data).To(HaveKeyWithValue("host", []byte("prod-db.example.com")))
 	})
 
-	It("resolves value via secretFrom with single argument (name only)", func() {
+	It("resolves value via secretFrom for root path secrets", func() {
 		rootCtx := v1.NewTemplateContext(
 			[]api.Secret{
 				{SecretKey: "MY_SECRET", SecretValue: "root-val", SecretPath: "/"},
@@ -227,7 +227,7 @@ var _ = Describe("RenderPerKeyTemplates with secretFrom", func() {
 			},
 		)
 		tmpls := map[string]string{
-			"secret": `{{ secretFrom "MY_SECRET" }}`,
+			"secret": `{{ secretFrom "/" "MY_SECRET" }}`,
 		}
 
 		data, err := v1.RenderPerKeyTemplates(tmpls, rootCtx)
@@ -403,5 +403,13 @@ other_path: "{{ (secretFrom "/folder/other" "API_KEY").SecretPath }}"`
 		Expect(err).NotTo(HaveOccurred())
 		Expect(data).To(HaveKeyWithValue("subfolder_path", []byte("/folder/subfolder")))
 		Expect(data).To(HaveKeyWithValue("other_path", []byte("/folder/other")))
+	})
+
+	It("errors if only one parameter is passed to secretPath", func() {
+		tmpl := `subfolder_path: "{{ (secretFrom "API_KEY").Value }}"`
+
+		_, err := v1.RenderBulkTemplate(tmpl, subfolderCtx)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("wrong number of args"))
 	})
 })

--- a/internal/template/v1/template_test.go
+++ b/internal/template/v1/template_test.go
@@ -86,7 +86,7 @@ var _ = Describe("BuildSecretTree", func() {
 	})
 })
 
-var _ = Describe("RenderPerKeyTemplates without secretRef", func() {
+var _ = Describe("RenderPerKeyTemplates without resolveSecretFromPath", func() {
 
 	rootSecrets := map[string]model.SecretTemplateOptions{
 		"DB_HOST": {Value: "localhost", SecretPath: "/"},
@@ -125,7 +125,7 @@ var _ = Describe("RenderPerKeyTemplates without secretRef", func() {
 	})
 })
 
-var _ = Describe("RenderBulkTemplate without secretRef", func() {
+var _ = Describe("RenderBulkTemplate without resolveSecretFromPath", func() {
 
 	rootSecrets := map[string]model.SecretTemplateOptions{
 		"DB_HOST": {Value: "localhost", SecretPath: "/"},
@@ -153,11 +153,11 @@ var _ = Describe("RenderBulkTemplate without secretRef", func() {
 	})
 })
 
-var _ = Describe("RenderPerKeyTemplates with secretRef", func() {
+var _ = Describe("RenderPerKeyTemplates with resolveSecretFromPath", func() {
 
-	It("resolves value via secretRef with nested path", func() {
+	It("resolves value via resolveSecretFromPath with nested path", func() {
 		tmpls := map[string]string{
-			"host": `{{ secretRef "folder.subfolder.DB_HOST.value" }}`,
+			"host": `{{ resolveSecretFromPath "folder.subfolder.DB_HOST.value" }}`,
 		}
 
 		data, err := v1.RenderPerKeyTemplates(tmpls, subfolderSecrets)
@@ -165,9 +165,9 @@ var _ = Describe("RenderPerKeyTemplates with secretRef", func() {
 		Expect(data).To(HaveKeyWithValue("host", []byte("prod-db.example.com")))
 	})
 
-	It("resolves secretPath via secretRef", func() {
+	It("resolves secretPath via resolveSecretFromPath", func() {
 		tmpls := map[string]string{
-			"path": `{{ secretRef "folder.subfolder.DB_HOST.secretPath" }}`,
+			"path": `{{ resolveSecretFromPath "folder.subfolder.DB_HOST.secretPath" }}`,
 		}
 
 		data, err := v1.RenderPerKeyTemplates(tmpls, subfolderSecrets)
@@ -177,7 +177,7 @@ var _ = Describe("RenderPerKeyTemplates with secretRef", func() {
 
 	It("resolves secrets from different subfolders in the same template", func() {
 		tmpls := map[string]string{
-			"combined": `{{ secretRef "folder.subfolder.DB_HOST.value" }}:{{ secretRef "folder.subfolder.DB_PORT.value" }} key={{ secretRef "folder.other.API_KEY.value" }}`,
+			"combined": `{{ resolveSecretFromPath "folder.subfolder.DB_HOST.value" }}:{{ resolveSecretFromPath "folder.subfolder.DB_PORT.value" }} key={{ resolveSecretFromPath "folder.other.API_KEY.value" }}`,
 		}
 
 		data, err := v1.RenderPerKeyTemplates(tmpls, subfolderSecrets)
@@ -187,7 +187,7 @@ var _ = Describe("RenderPerKeyTemplates with secretRef", func() {
 
 	It("returns error for unknown accessor", func() {
 		tmpls := map[string]string{
-			"bad": `{{ secretRef "folder.subfolder.DB_HOST.unknown" }}`,
+			"bad": `{{ resolveSecretFromPath "folder.subfolder.DB_HOST.unknown" }}`,
 		}
 
 		_, err := v1.RenderPerKeyTemplates(tmpls, subfolderSecrets)
@@ -197,7 +197,7 @@ var _ = Describe("RenderPerKeyTemplates with secretRef", func() {
 
 	It("returns error for non-existent path segment", func() {
 		tmpls := map[string]string{
-			"bad": `{{ secretRef "missing.DB_HOST.value" }}`,
+			"bad": `{{ resolveSecretFromPath "missing.DB_HOST.value" }}`,
 		}
 
 		_, err := v1.RenderPerKeyTemplates(tmpls, subfolderSecrets)
@@ -205,11 +205,11 @@ var _ = Describe("RenderPerKeyTemplates with secretRef", func() {
 		Expect(err.Error()).To(ContainSubstring("not found"))
 	})
 
-	It("does not duplicate values when ranging over all secrets alongside secretRef", func() {
+	It("does not duplicate values when ranging over all secrets alongside resolveSecretFromPath", func() {
 		tmpls := map[string]string{
-			"ref_host": `{{ secretRef "folder.subfolder.DB_HOST.value" }}`,
-			"ref_port": `{{ secretRef "folder.subfolder.DB_PORT.value" }}`,
-			"ref_key":  `{{ secretRef "folder.other.API_KEY.value" }}`,
+			"ref_host": `{{ resolveSecretFromPath "folder.subfolder.DB_HOST.value" }}`,
+			"ref_port": `{{ resolveSecretFromPath "folder.subfolder.DB_PORT.value" }}`,
+			"ref_key":  `{{ resolveSecretFromPath "folder.other.API_KEY.value" }}`,
 		}
 
 		data, err := v1.RenderPerKeyTemplates(tmpls, subfolderSecrets)
@@ -227,30 +227,30 @@ var _ = Describe("RenderPerKeyTemplates with secretRef", func() {
 				unique = append(unique, v)
 			}
 		}
-		Expect(unique).To(HaveLen(3), "each secretRef should resolve to a distinct value")
+		Expect(unique).To(HaveLen(3), "each resolveSecretFromPath should resolve to a distinct value")
 	})
 })
 
-var _ = Describe("RenderBulkTemplate with secretRef", func() {
+var _ = Describe("RenderBulkTemplate with resolveSecretFromPath", func() {
 
 	It("returns error for non-existent path segment", func() {
-		tmpl := `bad: "{{ secretRef "missing.DB_HOST.value" }}"`
+		tmpl := `bad: "{{ resolveSecretFromPath "missing.DB_HOST.value" }}"`
 
 		_, err := v1.RenderBulkTemplate(tmpl, subfolderSecrets)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("not found"))
 	})
 
-	It("resolves value via secretRef", func() {
-		tmpl := `host: "{{ secretRef "folder.subfolder.DB_HOST.value" }}"`
+	It("resolves value via resolveSecretFromPath", func() {
+		tmpl := `host: "{{ resolveSecretFromPath "folder.subfolder.DB_HOST.value" }}"`
 
 		data, err := v1.RenderBulkTemplate(tmpl, subfolderSecrets)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(data).To(HaveKeyWithValue("host", []byte("prod-db.example.com")))
 	})
 
-	It("resolves secretPath via secretRef", func() {
-		tmpl := `path: "{{ secretRef "folder.other.API_KEY.secretPath" }}"`
+	It("resolves secretPath via resolveSecretFromPath", func() {
+		tmpl := `path: "{{ resolveSecretFromPath "folder.other.API_KEY.secretPath" }}"`
 
 		data, err := v1.RenderBulkTemplate(tmpl, subfolderSecrets)
 		Expect(err).NotTo(HaveOccurred())
@@ -258,8 +258,8 @@ var _ = Describe("RenderBulkTemplate with secretRef", func() {
 	})
 
 	It("resolves multiple secrets from different subfolders", func() {
-		tmpl := `dsn: "{{ secretRef "folder.subfolder.DB_HOST.value" }}:{{ secretRef "folder.subfolder.DB_PORT.value" }}"
-api_key: "{{ secretRef "folder.other.API_KEY.value" }}"`
+		tmpl := `dsn: "{{ resolveSecretFromPath "folder.subfolder.DB_HOST.value" }}:{{ resolveSecretFromPath "folder.subfolder.DB_PORT.value" }}"
+api_key: "{{ resolveSecretFromPath "folder.other.API_KEY.value" }}"`
 
 		data, err := v1.RenderBulkTemplate(tmpl, subfolderSecrets)
 		Expect(err).NotTo(HaveOccurred())
@@ -268,10 +268,10 @@ api_key: "{{ secretRef "folder.other.API_KEY.value" }}"`
 		Expect(data).To(HaveKeyWithValue("api_key", []byte("sk-secret-123")))
 	})
 
-	It("does not duplicate values when rendering all secrets via secretRef", func() {
-		tmpl := `host: "{{ secretRef "folder.subfolder.DB_HOST.value" }}"
-port: "{{ secretRef "folder.subfolder.DB_PORT.value" }}"
-key: "{{ secretRef "folder.other.API_KEY.value" }}"`
+	It("does not duplicate values when rendering all secrets via resolveSecretFromPath", func() {
+		tmpl := `host: "{{ resolveSecretFromPath "folder.subfolder.DB_HOST.value" }}"
+port: "{{ resolveSecretFromPath "folder.subfolder.DB_PORT.value" }}"
+key: "{{ resolveSecretFromPath "folder.other.API_KEY.value" }}"`
 
 		data, err := v1.RenderBulkTemplate(tmpl, subfolderSecrets)
 		Expect(err).NotTo(HaveOccurred())
@@ -288,6 +288,6 @@ key: "{{ secretRef "folder.other.API_KEY.value" }}"`
 				unique = append(unique, v)
 			}
 		}
-		Expect(unique).To(HaveLen(3), "each secretRef should resolve to a distinct value")
+		Expect(unique).To(HaveLen(3), "each resolveSecretFromPath should resolve to a distinct value")
 	})
 })

--- a/internal/template/v1/template_test.go
+++ b/internal/template/v1/template_test.go
@@ -3,26 +3,35 @@ package v1_test
 import (
 	"sort"
 
+	"github.com/Infisical/infisical/k8-operator/internal/api"
 	"github.com/Infisical/infisical/k8-operator/internal/model"
 	v1 "github.com/Infisical/infisical/k8-operator/internal/template/v1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
-var subfolderSecrets = map[string]model.SecretTemplateOptions{
-	"DB_HOST": {Value: "prod-db.example.com", SecretPath: "/folder/subfolder"},
-	"DB_PORT": {Value: "5432", SecretPath: "/folder/subfolder"},
-	"API_KEY": {Value: "sk-secret-123", SecretPath: "/folder/other"},
-}
+var subfolderCtx = v1.NewTemplateContext(
+	[]api.Secret{
+		{SecretKey: "DB_HOST", SecretValue: "prod-db.example.com", SecretPath: "/folder/subfolder"},
+		{SecretKey: "DB_PORT", SecretValue: "5432", SecretPath: "/folder/subfolder"},
+		{SecretKey: "API_KEY", SecretValue: "subfolder-secret", SecretPath: "/folder/subfolder"},
+		{SecretKey: "API_KEY", SecretValue: "other-secret", SecretPath: "/folder/other"},
+	},
+	[]api.Secret{
+		{SecretKey: "DB_HOST", SecretValue: "prod-db.example.com", SecretPath: "/folder/subfolder"},
+		{SecretKey: "DB_PORT", SecretValue: "5432", SecretPath: "/folder/subfolder"},
+		{SecretKey: "API_KEY", SecretValue: "other-secret", SecretPath: "/folder/other"},
+	},
+)
 
 var _ = Describe("BuildSecretTree", func() {
 
 	It("places secrets in nested subfolders", func() {
-		ctx := map[string]model.SecretTemplateOptions{
-			"SECRET_1": {Value: "val1", SecretPath: "/folder/subfolder"},
-			"SECRET_2": {Value: "val2", SecretPath: "/folder/subfolder"},
-			"SECRET_3": {Value: "val3", SecretPath: "/folder/another"},
-		}
+		ctx := v1.NewTemplateContext([]api.Secret{
+			{SecretKey: "SECRET_1", SecretValue: "val1", SecretPath: "/folder/subfolder"},
+			{SecretKey: "SECRET_2", SecretValue: "val2", SecretPath: "/folder/subfolder"},
+			{SecretKey: "SECRET_3", SecretValue: "val3", SecretPath: "/folder/another"},
+		}, nil)
 
 		tree := v1.BuildSecretTree(ctx)
 
@@ -40,23 +49,24 @@ var _ = Describe("BuildSecretTree", func() {
 	})
 
 	It("places secrets at the root path", func() {
-		ctx := map[string]model.SecretTemplateOptions{
-			"ROOT_SECRET": {Value: "root-val", SecretPath: "/"},
-		}
+		ctx := v1.NewTemplateContext([]api.Secret{
+			{SecretKey: "ROOT_SECRET", SecretValue: "root-val", SecretPath: "/"},
+		}, nil)
 
 		tree := v1.BuildSecretTree(ctx)
 		Expect(tree["ROOT_SECRET"]).To(Equal(model.SecretTemplateOptions{Value: "root-val", SecretPath: "/"}))
 	})
 
 	It("returns an empty tree for empty context", func() {
-		tree := v1.BuildSecretTree(map[string]model.SecretTemplateOptions{})
+		ctx := v1.NewTemplateContext(nil, nil)
+		tree := v1.BuildSecretTree(ctx)
 		Expect(tree).To(BeEmpty())
 	})
 
 	It("handles deeply nested paths", func() {
-		ctx := map[string]model.SecretTemplateOptions{
-			"DEEP": {Value: "deep-val", SecretPath: "/a/b/c/d"},
-		}
+		ctx := v1.NewTemplateContext([]api.Secret{
+			{SecretKey: "DEEP", SecretValue: "deep-val", SecretPath: "/a/b/c/d"},
+		}, nil)
 
 		tree := v1.BuildSecretTree(ctx)
 
@@ -72,10 +82,10 @@ var _ = Describe("BuildSecretTree", func() {
 	})
 
 	It("handles mixed root and nested secrets", func() {
-		ctx := map[string]model.SecretTemplateOptions{
-			"AT_ROOT":   {Value: "r", SecretPath: "/"},
-			"IN_FOLDER": {Value: "f", SecretPath: "/app"},
-		}
+		ctx := v1.NewTemplateContext([]api.Secret{
+			{SecretKey: "AT_ROOT", SecretValue: "r", SecretPath: "/"},
+			{SecretKey: "IN_FOLDER", SecretValue: "f", SecretPath: "/app"},
+		}, nil)
 
 		tree := v1.BuildSecretTree(ctx)
 
@@ -88,18 +98,18 @@ var _ = Describe("BuildSecretTree", func() {
 
 var _ = Describe("RenderPerKeyTemplates without resolveSecretFromPath", func() {
 
-	rootSecrets := map[string]model.SecretTemplateOptions{
-		"DB_HOST": {Value: "localhost", SecretPath: "/"},
-		"DB_PORT": {Value: "5432", SecretPath: "/"},
-		"DB_NAME": {Value: "mydb", SecretPath: "/"},
-	}
+	rootCtx := v1.NewTemplateContext(nil, []api.Secret{
+		{SecretKey: "DB_HOST", SecretValue: "localhost", SecretPath: "/"},
+		{SecretKey: "DB_PORT", SecretValue: "5432", SecretPath: "/"},
+		{SecretKey: "DB_NAME", SecretValue: "mydb", SecretPath: "/"},
+	})
 
 	It("resolves .Value accessor directly", func() {
 		tmpls := map[string]string{
 			"host": `{{ .DB_HOST.Value }}`,
 		}
 
-		data, err := v1.RenderPerKeyTemplates(tmpls, rootSecrets)
+		data, err := v1.RenderPerKeyTemplates(tmpls, rootCtx)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(data).To(HaveKeyWithValue("host", []byte("localhost")))
 	})
@@ -109,7 +119,7 @@ var _ = Describe("RenderPerKeyTemplates without resolveSecretFromPath", func() {
 			"path": `{{ .DB_HOST.SecretPath }}`,
 		}
 
-		data, err := v1.RenderPerKeyTemplates(tmpls, rootSecrets)
+		data, err := v1.RenderPerKeyTemplates(tmpls, rootCtx)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(data).To(HaveKeyWithValue("path", []byte("/")))
 	})
@@ -119,7 +129,7 @@ var _ = Describe("RenderPerKeyTemplates without resolveSecretFromPath", func() {
 			"dsn": `postgresql://user:pass@{{ .DB_HOST.Value }}:{{ .DB_PORT.Value }}/{{ .DB_NAME.Value }}`,
 		}
 
-		data, err := v1.RenderPerKeyTemplates(tmpls, rootSecrets)
+		data, err := v1.RenderPerKeyTemplates(tmpls, rootCtx)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(data).To(HaveKeyWithValue("dsn", []byte("postgresql://user:pass@localhost:5432/mydb")))
 	})
@@ -127,15 +137,15 @@ var _ = Describe("RenderPerKeyTemplates without resolveSecretFromPath", func() {
 
 var _ = Describe("RenderBulkTemplate without resolveSecretFromPath", func() {
 
-	rootSecrets := map[string]model.SecretTemplateOptions{
-		"DB_HOST": {Value: "localhost", SecretPath: "/"},
-		"DB_PORT": {Value: "5432", SecretPath: "/"},
-	}
+	rootCtx := v1.NewTemplateContext(nil, []api.Secret{
+		{SecretKey: "DB_HOST", SecretValue: "localhost", SecretPath: "/"},
+		{SecretKey: "DB_PORT", SecretValue: "5432", SecretPath: "/"},
+	})
 
 	It("resolves .Value accessor directly", func() {
 		tmpl := `host: "{{ .DB_HOST.Value }}"`
 
-		data, err := v1.RenderBulkTemplate(tmpl, rootSecrets)
+		data, err := v1.RenderBulkTemplate(tmpl, rootCtx)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(data).To(HaveKeyWithValue("host", []byte("localhost")))
 	})
@@ -145,7 +155,7 @@ var _ = Describe("RenderBulkTemplate without resolveSecretFromPath", func() {
 {{ $key }}: "{{ $secret.Value }}"
 {{- end }}`
 
-		data, err := v1.RenderBulkTemplate(tmpl, rootSecrets)
+		data, err := v1.RenderBulkTemplate(tmpl, rootCtx)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(data).To(HaveLen(2))
 		Expect(data).To(HaveKeyWithValue("DB_HOST", []byte("localhost")))
@@ -160,7 +170,7 @@ var _ = Describe("RenderPerKeyTemplates with resolveSecretFromPath", func() {
 			"host": `{{ resolveSecretFromPath "folder.subfolder.DB_HOST.value" }}`,
 		}
 
-		data, err := v1.RenderPerKeyTemplates(tmpls, subfolderSecrets)
+		data, err := v1.RenderPerKeyTemplates(tmpls, subfolderCtx)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(data).To(HaveKeyWithValue("host", []byte("prod-db.example.com")))
 	})
@@ -170,7 +180,7 @@ var _ = Describe("RenderPerKeyTemplates with resolveSecretFromPath", func() {
 			"path": `{{ resolveSecretFromPath "folder.subfolder.DB_HOST.secretPath" }}`,
 		}
 
-		data, err := v1.RenderPerKeyTemplates(tmpls, subfolderSecrets)
+		data, err := v1.RenderPerKeyTemplates(tmpls, subfolderCtx)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(data).To(HaveKeyWithValue("path", []byte("/folder/subfolder")))
 	})
@@ -180,9 +190,9 @@ var _ = Describe("RenderPerKeyTemplates with resolveSecretFromPath", func() {
 			"combined": `{{ resolveSecretFromPath "folder.subfolder.DB_HOST.value" }}:{{ resolveSecretFromPath "folder.subfolder.DB_PORT.value" }} key={{ resolveSecretFromPath "folder.other.API_KEY.value" }}`,
 		}
 
-		data, err := v1.RenderPerKeyTemplates(tmpls, subfolderSecrets)
+		data, err := v1.RenderPerKeyTemplates(tmpls, subfolderCtx)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(data).To(HaveKeyWithValue("combined", []byte("prod-db.example.com:5432 key=sk-secret-123")))
+		Expect(data).To(HaveKeyWithValue("combined", []byte("prod-db.example.com:5432 key=other-secret")))
 	})
 
 	It("returns error for unknown accessor", func() {
@@ -190,7 +200,7 @@ var _ = Describe("RenderPerKeyTemplates with resolveSecretFromPath", func() {
 			"bad": `{{ resolveSecretFromPath "folder.subfolder.DB_HOST.unknown" }}`,
 		}
 
-		_, err := v1.RenderPerKeyTemplates(tmpls, subfolderSecrets)
+		_, err := v1.RenderPerKeyTemplates(tmpls, subfolderCtx)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("unknown accessor"))
 	})
@@ -200,7 +210,7 @@ var _ = Describe("RenderPerKeyTemplates with resolveSecretFromPath", func() {
 			"bad": `{{ resolveSecretFromPath "missing.DB_HOST.value" }}`,
 		}
 
-		_, err := v1.RenderPerKeyTemplates(tmpls, subfolderSecrets)
+		_, err := v1.RenderPerKeyTemplates(tmpls, subfolderCtx)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("not found"))
 	})
@@ -212,7 +222,7 @@ var _ = Describe("RenderPerKeyTemplates with resolveSecretFromPath", func() {
 			"ref_key":  `{{ resolveSecretFromPath "folder.other.API_KEY.value" }}`,
 		}
 
-		data, err := v1.RenderPerKeyTemplates(tmpls, subfolderSecrets)
+		data, err := v1.RenderPerKeyTemplates(tmpls, subfolderCtx)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(data).To(HaveLen(3))
 
@@ -228,6 +238,30 @@ var _ = Describe("RenderPerKeyTemplates with resolveSecretFromPath", func() {
 			}
 		}
 		Expect(unique).To(HaveLen(3), "each resolveSecretFromPath should resolve to a distinct value")
+	})
+
+	It("resolves duplicate secret keys from different paths", func() {
+		tmpls := map[string]string{
+			"subfolder_key": `{{ resolveSecretFromPath "folder.subfolder.API_KEY.value" }}`,
+			"other_key":     `{{ resolveSecretFromPath "folder.other.API_KEY.value" }}`,
+		}
+
+		data, err := v1.RenderPerKeyTemplates(tmpls, subfolderCtx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(data).To(HaveKeyWithValue("subfolder_key", []byte("subfolder-secret")))
+		Expect(data).To(HaveKeyWithValue("other_key", []byte("other-secret")))
+	})
+
+	It("resolves secretPath of duplicate secret keys from different paths", func() {
+		tmpls := map[string]string{
+			"subfolder_path": `{{ resolveSecretFromPath "folder.subfolder.API_KEY.secretPath" }}`,
+			"other_path":     `{{ resolveSecretFromPath "folder.other.API_KEY.secretPath" }}`,
+		}
+
+		data, err := v1.RenderPerKeyTemplates(tmpls, subfolderCtx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(data).To(HaveKeyWithValue("subfolder_path", []byte("/folder/subfolder")))
+		Expect(data).To(HaveKeyWithValue("other_path", []byte("/folder/other")))
 	})
 })
 
@@ -236,7 +270,7 @@ var _ = Describe("RenderBulkTemplate with resolveSecretFromPath", func() {
 	It("returns error for non-existent path segment", func() {
 		tmpl := `bad: "{{ resolveSecretFromPath "missing.DB_HOST.value" }}"`
 
-		_, err := v1.RenderBulkTemplate(tmpl, subfolderSecrets)
+		_, err := v1.RenderBulkTemplate(tmpl, subfolderCtx)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("not found"))
 	})
@@ -244,7 +278,7 @@ var _ = Describe("RenderBulkTemplate with resolveSecretFromPath", func() {
 	It("resolves value via resolveSecretFromPath", func() {
 		tmpl := `host: "{{ resolveSecretFromPath "folder.subfolder.DB_HOST.value" }}"`
 
-		data, err := v1.RenderBulkTemplate(tmpl, subfolderSecrets)
+		data, err := v1.RenderBulkTemplate(tmpl, subfolderCtx)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(data).To(HaveKeyWithValue("host", []byte("prod-db.example.com")))
 	})
@@ -252,7 +286,7 @@ var _ = Describe("RenderBulkTemplate with resolveSecretFromPath", func() {
 	It("resolves secretPath via resolveSecretFromPath", func() {
 		tmpl := `path: "{{ resolveSecretFromPath "folder.other.API_KEY.secretPath" }}"`
 
-		data, err := v1.RenderBulkTemplate(tmpl, subfolderSecrets)
+		data, err := v1.RenderBulkTemplate(tmpl, subfolderCtx)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(data).To(HaveKeyWithValue("path", []byte("/folder/other")))
 	})
@@ -261,11 +295,11 @@ var _ = Describe("RenderBulkTemplate with resolveSecretFromPath", func() {
 		tmpl := `dsn: "{{ resolveSecretFromPath "folder.subfolder.DB_HOST.value" }}:{{ resolveSecretFromPath "folder.subfolder.DB_PORT.value" }}"
 api_key: "{{ resolveSecretFromPath "folder.other.API_KEY.value" }}"`
 
-		data, err := v1.RenderBulkTemplate(tmpl, subfolderSecrets)
+		data, err := v1.RenderBulkTemplate(tmpl, subfolderCtx)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(data).To(HaveLen(2))
 		Expect(data).To(HaveKeyWithValue("dsn", []byte("prod-db.example.com:5432")))
-		Expect(data).To(HaveKeyWithValue("api_key", []byte("sk-secret-123")))
+		Expect(data).To(HaveKeyWithValue("api_key", []byte("other-secret")))
 	})
 
 	It("does not duplicate values when rendering all secrets via resolveSecretFromPath", func() {
@@ -273,7 +307,7 @@ api_key: "{{ resolveSecretFromPath "folder.other.API_KEY.value" }}"`
 port: "{{ resolveSecretFromPath "folder.subfolder.DB_PORT.value" }}"
 key: "{{ resolveSecretFromPath "folder.other.API_KEY.value" }}"`
 
-		data, err := v1.RenderBulkTemplate(tmpl, subfolderSecrets)
+		data, err := v1.RenderBulkTemplate(tmpl, subfolderCtx)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(data).To(HaveLen(3))
 
@@ -289,5 +323,25 @@ key: "{{ resolveSecretFromPath "folder.other.API_KEY.value" }}"`
 			}
 		}
 		Expect(unique).To(HaveLen(3), "each resolveSecretFromPath should resolve to a distinct value")
+	})
+
+	It("resolves duplicate secret keys from different paths", func() {
+		tmpl := `subfolder_key: "{{ resolveSecretFromPath "folder.subfolder.API_KEY.value" }}"
+other_key: "{{ resolveSecretFromPath "folder.other.API_KEY.value" }}"`
+
+		data, err := v1.RenderBulkTemplate(tmpl, subfolderCtx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(data).To(HaveKeyWithValue("subfolder_key", []byte("subfolder-secret")))
+		Expect(data).To(HaveKeyWithValue("other_key", []byte("other-secret")))
+	})
+
+	It("resolves secretPath of duplicate secret keys from different paths", func() {
+		tmpl := `subfolder_path: "{{ resolveSecretFromPath "folder.subfolder.API_KEY.secretPath" }}"
+other_path: "{{ resolveSecretFromPath "folder.other.API_KEY.secretPath" }}"`
+
+		data, err := v1.RenderBulkTemplate(tmpl, subfolderCtx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(data).To(HaveKeyWithValue("subfolder_path", []byte("/folder/subfolder")))
+		Expect(data).To(HaveKeyWithValue("other_path", []byte("/folder/other")))
 	})
 })

--- a/internal/template/v1/template_test.go
+++ b/internal/template/v1/template_test.go
@@ -81,6 +81,28 @@ var _ = Describe("BuildSecretTree", func() {
 		Expect(d["DEEP"]).To(Equal(model.SecretTemplateOptions{Value: "deep-val", SecretPath: "/a/b/c/d"}))
 	})
 
+	It("keeps first occurrence when duplicate keys exist at the same path", func() {
+		ctx := v1.NewTemplateContext([]api.Secret{
+			{SecretKey: "DB_HOST", SecretValue: "project-a-host", SecretPath: "/shared"},
+			{SecretKey: "DB_PORT", SecretValue: "5432", SecretPath: "/shared"},
+			{SecretKey: "DB_HOST", SecretValue: "project-b-host", SecretPath: "/shared"},
+			{SecretKey: "API_KEY", SecretValue: "key-from-b", SecretPath: "/shared"},
+			{SecretKey: "DB_PORT", SecretValue: "1234", SecretPath: "/db"},
+		}, nil)
+
+		tree := v1.BuildSecretTree(ctx)
+
+		shared, ok := tree["shared"].(map[string]any)
+		Expect(ok).To(BeTrue())
+		Expect(shared["DB_HOST"]).To(Equal(model.SecretTemplateOptions{Value: "project-a-host", SecretPath: "/shared"}))
+		Expect(shared["DB_PORT"]).To(Equal(model.SecretTemplateOptions{Value: "5432", SecretPath: "/shared"}))
+		Expect(shared["API_KEY"]).To(Equal(model.SecretTemplateOptions{Value: "key-from-b", SecretPath: "/shared"}))
+
+		db, ok := tree["db"].(map[string]any)
+		Expect(ok).To(BeTrue())
+		Expect(db["DB_PORT"]).To(Equal(model.SecretTemplateOptions{Value: "1234", SecretPath: "/db"}))
+	})
+
 	It("handles mixed root and nested secrets", func() {
 		ctx := v1.NewTemplateContext([]api.Secret{
 			{SecretKey: "AT_ROOT", SecretValue: "r", SecretPath: "/"},

--- a/test/e2e/e2e_staticsecret_test.go
+++ b/test/e2e/e2e_staticsecret_test.go
@@ -377,6 +377,47 @@ var _ = Describe("InfisicalStaticSecret", Ordered, ContinueOnFailure, func() {
 		})
 	})
 
+	It("should resolve duplicate keys from different paths via resolveSecretFromPath", func() {
+		api.CreateFolder(GinkgoT(), project.ID, project.EnvSlug, "/", "resolve-tpl")
+		api.CreateFolder(GinkgoT(), project.ID, project.EnvSlug, "/resolve-tpl", "db")
+		api.CreateFolder(GinkgoT(), project.ID, project.EnvSlug, "/resolve-tpl", "cache")
+		api.CreateSecret(GinkgoT(), project.ID, project.EnvSlug, "/resolve-tpl/db", "HOST", "db.internal", nil)
+		api.CreateSecret(GinkgoT(), project.ID, project.EnvSlug, "/resolve-tpl/cache", "HOST", "cache.internal", nil)
+
+		createStaticSecret("e2e-resolve-path-sync", secretsv1beta1.InfisicalStaticSecretSpec{
+			InfisicalAuthRef: authRef,
+			SyncOptions:      &secretsv1beta1.SyncOptions{RefreshInterval: "1h"},
+			Sources: []secretsv1beta1.SecretSource{{
+				ProjectId:       project.ID,
+				EnvironmentSlug: project.EnvSlug,
+				SecretPath:      "/resolve-tpl",
+				Recursive:       true,
+			}},
+			Targets: []secretsv1beta1.SecretTarget{{
+				Name:           "e2e-resolve-path-synced",
+				Namespace:      testNamespace,
+				Kind:           secretsv1beta1.SecretTargetKindSecret,
+				SecretType:     corev1.SecretTypeOpaque,
+				CreationPolicy: secretsv1beta1.CreationPolicyOwner,
+				Template: &secretsv1beta1.SecretTemplate{
+					EngineVersion: "v1",
+					Data: secretsv1beta1.SecretTemplateData{
+						Map: map[string]string{
+							"DB_HOST":    `{{ resolveSecretFromPath "resolve-tpl.db.HOST.value" }}`,
+							"CACHE_HOST": `{{ resolveSecretFromPath "resolve-tpl.cache.HOST.value" }}`,
+						},
+					},
+				},
+			}},
+		})
+
+		synced := expectSecret("e2e-resolve-path-synced", "e2e-resolve-path-sync")
+		expectSecretData(synced, map[string]string{
+			"DB_HOST":    "db.internal",
+			"CACHE_HOST": "cache.internal",
+		})
+	})
+
 	It("should apply target metadata", func() {
 		api.CreateFolder(GinkgoT(), project.ID, project.EnvSlug, "/", "labeled")
 		api.CreateSecret(GinkgoT(), project.ID, project.EnvSlug, "/labeled", "TOKEN", "abc123", nil)

--- a/test/e2e/e2e_staticsecret_test.go
+++ b/test/e2e/e2e_staticsecret_test.go
@@ -377,7 +377,7 @@ var _ = Describe("InfisicalStaticSecret", Ordered, ContinueOnFailure, func() {
 		})
 	})
 
-	It("should resolve duplicate keys from different paths via getSecretByPath", func() {
+	It("should resolve duplicate keys from different paths via secretFrom", func() {
 		api.CreateFolder(GinkgoT(), project.ID, project.EnvSlug, "/", "resolve-tpl")
 		api.CreateFolder(GinkgoT(), project.ID, project.EnvSlug, "/resolve-tpl", "db")
 		api.CreateFolder(GinkgoT(), project.ID, project.EnvSlug, "/resolve-tpl", "cache")
@@ -403,8 +403,8 @@ var _ = Describe("InfisicalStaticSecret", Ordered, ContinueOnFailure, func() {
 					EngineVersion: "v1",
 					Data: secretsv1beta1.SecretTemplateData{
 						Map: map[string]string{
-							"DB_HOST":    `{{ getSecretByPath "resolve-tpl/db/HOST" }}`,
-							"CACHE_HOST": `{{ (getSecretByPath "resolve-tpl/cache/HOST").Value }}`,
+							"DB_HOST":    `{{ secretFrom "/resolve-tpl/db" "HOST" }}`,
+							"CACHE_HOST": `{{ (secretFrom "/resolve-tpl/cache" "HOST").Value }}`,
 						},
 					},
 				},

--- a/test/e2e/e2e_staticsecret_test.go
+++ b/test/e2e/e2e_staticsecret_test.go
@@ -377,7 +377,7 @@ var _ = Describe("InfisicalStaticSecret", Ordered, ContinueOnFailure, func() {
 		})
 	})
 
-	It("should resolve duplicate keys from different paths via resolveSecretFromPath", func() {
+	It("should resolve duplicate keys from different paths via getSecretByPath", func() {
 		api.CreateFolder(GinkgoT(), project.ID, project.EnvSlug, "/", "resolve-tpl")
 		api.CreateFolder(GinkgoT(), project.ID, project.EnvSlug, "/resolve-tpl", "db")
 		api.CreateFolder(GinkgoT(), project.ID, project.EnvSlug, "/resolve-tpl", "cache")
@@ -403,8 +403,8 @@ var _ = Describe("InfisicalStaticSecret", Ordered, ContinueOnFailure, func() {
 					EngineVersion: "v1",
 					Data: secretsv1beta1.SecretTemplateData{
 						Map: map[string]string{
-							"DB_HOST":    `{{ resolveSecretFromPath "resolve-tpl.db.HOST.value" }}`,
-							"CACHE_HOST": `{{ resolveSecretFromPath "resolve-tpl.cache.HOST.value" }}`,
+							"DB_HOST":    `{{ getSecretByPath "resolve-tpl/db/HOST" }}`,
+							"CACHE_HOST": `{{ (getSecretByPath "resolve-tpl/cache/HOST").Value }}`,
 						},
 					},
 				},


### PR DESCRIPTION
## Context

It allows users to reference a secret by using the `secretFrom` function:

```yaml
SECRET: {{ secretFrom "/folder/subfolder" "SECRET_NAME" }}
SECRET2: {{ (secretFrom "/folder/subfolder" "SECRET_NAME").Value }}
SECRET_PATH: {{ (secretFrom "/folder/subfolder" "SECRET_NAME").SecretPath }}
```

This access a secret by its path. This is especially useful for cases where the default behavior of our kubernetes operator drops a secret because its `key` conflicts with another secret of different path. It means that you can access secrets with same key, but different paths.

Also, this PR makes `.Value` optional. If omitted, the value will be resolved. This works for both: `secretFrom` and the regular way of accessing secrets: 

```yaml
SECRET: {{ .SECRET_NAME.Value }}
SECRET_2: {{ .SECRET_NAME }}
```