### PR TITLE
fix: race conditionn in k8s API

### DIFF
--- a/internal/services/infisicalstaticsecret/handler.go
+++ b/internal/services/infisicalstaticsecret/handler.go
@@ -234,14 +234,15 @@ func (h *InfisicalStaticSecretHandler) syncTargetSecrets(ctx context.Context, ow
 		return 0, fmt.Errorf("failed to render target output: %w", err)
 	}
 
-	var targetResourceChanged = false
+	var targetResourceChanged bool
+	var etag string
 	if target.Kind == v1beta1.SecretTargetKindSecret {
-		targetResourceChanged, err = h.reconciler.SyncKubeSecret(ctx, owner, content, target)
+		targetResourceChanged, etag, err = h.reconciler.SyncKubeSecret(ctx, owner, content, target)
 		if err != nil {
 			return 0, fmt.Errorf("failed to sync Secret %q: %w", target.Name, err)
 		}
 	} else if target.Kind == v1beta1.SecretTargetKindConfigMap {
-		targetResourceChanged, err = h.reconciler.SyncKubeConfigMap(ctx, owner, content, target)
+		targetResourceChanged, etag, err = h.reconciler.SyncKubeConfigMap(ctx, owner, content, target)
 		if err != nil {
 			return 0, fmt.Errorf("failed to sync ConfigMap %q: %w", target.Name, err)
 		}
@@ -250,7 +251,7 @@ func (h *InfisicalStaticSecretHandler) syncTargetSecrets(ctx context.Context, ow
 	}
 
 	if targetResourceChanged {
-		affectedWorkloads, err := h.reconciler.PropagateSecretToWorkloads(ctx, target)
+		affectedWorkloads, err := h.reconciler.PropagateSecretToWorkloads(ctx, target, etag)
 		if err != nil {
 			return affectedWorkloads, fmt.Errorf("failed to reconcile dependent resources of target %q: %w", target.Name, err)
 		}

--- a/internal/services/infisicalstaticsecret/reconciler.go
+++ b/internal/services/infisicalstaticsecret/reconciler.go
@@ -459,8 +459,8 @@ func renderBulkTemplate(tmplStr string, ctx map[string]model.SecretTemplateOptio
 }
 
 // SyncKubeSecret creates or updates a Kubernetes Secret with the secrets content.
-// Returns true when secret data changed (triggers workload propagation).
-func (r *InfisicalStaticSecretReconciler) SyncKubeSecret(ctx context.Context, owner metav1.Object, data map[string][]byte, target v1beta1.SecretTarget) (bool, error) {
+// Returns (changed, etag, error). The etag is the version written to the annotation.
+func (r *InfisicalStaticSecretReconciler) SyncKubeSecret(ctx context.Context, owner metav1.Object, data map[string][]byte, target v1beta1.SecretTarget) (bool, string, error) {
 	newEtag := crypto.ComputeEtag([]byte(fmt.Sprintf("%v", data)))
 
 	namespacedName := types.NamespacedName{
@@ -488,19 +488,19 @@ func (r *InfisicalStaticSecretReconciler) SyncKubeSecret(ctx context.Context, ow
 
 		if target.CreationPolicy == v1beta1.CreationPolicyOwner {
 			if err := ctrl.SetControllerReference(owner, newSecret, r.Scheme); err != nil {
-				return false, fmt.Errorf("failed to set owner reference: %w", err)
+				return false, "", fmt.Errorf("failed to set owner reference: %w", err)
 			}
 		}
 
 		if err := r.Client.Create(ctx, newSecret); err != nil {
-			return false, fmt.Errorf("failed to create secret: %w", err)
+			return false, "", fmt.Errorf("failed to create secret: %w", err)
 		}
 
-		return true, nil
+		return true, newEtag, nil
 	}
 
 	if err != nil {
-		return false, fmt.Errorf("failed to get existing secret: %w", err)
+		return false, "", fmt.Errorf("failed to get existing secret: %w", err)
 	}
 
 	dataChanged := existingSecret.Annotations[constants.SECRET_VERSION_ANNOTATION] != newEtag
@@ -511,22 +511,22 @@ func (r *InfisicalStaticSecretReconciler) SyncKubeSecret(ctx context.Context, ow
 	metadataChanged := !maps.Equal(existingSecret.Labels, labels) || !maps.Equal(existingSecret.Annotations, annotations)
 
 	if !dataChanged && !metadataChanged {
-		return false, nil
+		return false, newEtag, nil
 	}
 
 	existingSecret.Labels = labels
 	existingSecret.Annotations = annotations
 	existingSecret.Data = data
 	if err := r.Client.Update(ctx, existingSecret); err != nil {
-		return false, fmt.Errorf("failed to update secret: %w", err)
+		return false, "", fmt.Errorf("failed to update secret: %w", err)
 	}
 
-	return dataChanged, nil
+	return dataChanged, newEtag, nil
 }
 
 // SyncKubeConfigMap creates or updates a Kubernetes ConfigMap with the secrets content.
-// Returns true when config map data changed (triggers workload propagation).
-func (r *InfisicalStaticSecretReconciler) SyncKubeConfigMap(ctx context.Context, owner metav1.Object, data map[string][]byte, target v1beta1.SecretTarget) (bool, error) {
+// Returns (changed, etag, error). The etag is the version written to the annotation.
+func (r *InfisicalStaticSecretReconciler) SyncKubeConfigMap(ctx context.Context, owner metav1.Object, data map[string][]byte, target v1beta1.SecretTarget) (bool, string, error) {
 	newEtag := crypto.ComputeEtag([]byte(fmt.Sprintf("%v", data)))
 
 	namespacedName := types.NamespacedName{
@@ -558,19 +558,19 @@ func (r *InfisicalStaticSecretReconciler) SyncKubeConfigMap(ctx context.Context,
 
 		if target.CreationPolicy == v1beta1.CreationPolicyOwner {
 			if err := ctrl.SetControllerReference(owner, newConfigMap, r.Scheme); err != nil {
-				return false, fmt.Errorf("failed to set owner reference: %w", err)
+				return false, "", fmt.Errorf("failed to set owner reference: %w", err)
 			}
 		}
 
 		if err := r.Client.Create(ctx, newConfigMap); err != nil {
-			return false, fmt.Errorf("failed to create config map: %w", err)
+			return false, "", fmt.Errorf("failed to create config map: %w", err)
 		}
 
-		return true, nil
+		return true, newEtag, nil
 	}
 
 	if err != nil {
-		return false, fmt.Errorf("failed to get existing config map: %w", err)
+		return false, "", fmt.Errorf("failed to get existing config map: %w", err)
 	}
 
 	dataChanged := existingConfigMap.Annotations[constants.SECRET_VERSION_ANNOTATION] != newEtag
@@ -581,7 +581,7 @@ func (r *InfisicalStaticSecretReconciler) SyncKubeConfigMap(ctx context.Context,
 	metadataChanged := !maps.Equal(existingConfigMap.Labels, labels) || !maps.Equal(existingConfigMap.Annotations, annotations)
 
 	if !dataChanged && !metadataChanged {
-		return false, nil
+		return false, newEtag, nil
 	}
 
 	stringData := make(map[string]string, len(data))
@@ -593,41 +593,13 @@ func (r *InfisicalStaticSecretReconciler) SyncKubeConfigMap(ctx context.Context,
 	existingConfigMap.Annotations = annotations
 	existingConfigMap.Data = stringData
 	if err := r.Client.Update(ctx, existingConfigMap); err != nil {
-		return false, fmt.Errorf("failed to update config map: %w", err)
+		return false, "", fmt.Errorf("failed to update config map: %w", err)
 	}
 
-	return dataChanged, nil
+	return dataChanged, newEtag, nil
 }
 
-func (r *InfisicalStaticSecretReconciler) getTargetEtag(ctx context.Context, target v1beta1.SecretTarget) (string, error) {
-	nn := types.NamespacedName{Name: target.Name, Namespace: target.Namespace}
-
-	switch target.Kind {
-	case v1beta1.SecretTargetKindSecret:
-		s := &corev1.Secret{}
-		if err := r.Client.Get(ctx, nn, s); err != nil {
-			return "", fmt.Errorf("failed to get target Secret %q: %w", target.Name, err)
-		}
-		return s.Annotations[constants.SECRET_VERSION_ANNOTATION], nil
-
-	case v1beta1.SecretTargetKindConfigMap:
-		cm := &corev1.ConfigMap{}
-		if err := r.Client.Get(ctx, nn, cm); err != nil {
-			return "", fmt.Errorf("failed to get target ConfigMap %q: %w", target.Name, err)
-		}
-		return cm.Annotations[constants.SECRET_VERSION_ANNOTATION], nil
-
-	default:
-		return "", fmt.Errorf("unsupported target kind %q", target.Kind)
-	}
-}
-
-func (r *InfisicalStaticSecretReconciler) PropagateSecretToWorkloads(ctx context.Context, target v1beta1.SecretTarget) (int, error) {
-	etag, err := r.getTargetEtag(ctx, target)
-	if err != nil {
-		return 0, err
-	}
-
+func (r *InfisicalStaticSecretReconciler) PropagateSecretToWorkloads(ctx context.Context, target v1beta1.SecretTarget, etag string) (int, error) {
 	annotationKey := fmt.Sprintf(ManagedSecretAnnotationFmt, target.Name)
 
 	workloads, err := r.listWorkloadsConsumingTarget(ctx, target)

--- a/internal/services/infisicalstaticsecret/reconciler_test.go
+++ b/internal/services/infisicalstaticsecret/reconciler_test.go
@@ -17,8 +17,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	k8Errors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
 
 func secret(key, env, path string) api.Secret {
@@ -551,7 +554,7 @@ var _ = Describe("SyncKubeSecret", func() {
 		reconciler := newReconciler()
 		owner := newStaticSecret()
 
-		changed, err := reconciler.SyncKubeSecret(ctx, owner, data, target)
+		changed, _, err := reconciler.SyncKubeSecret(ctx, owner, data, target)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(changed).To(BeTrue())
 
@@ -573,7 +576,7 @@ var _ = Describe("SyncKubeSecret", func() {
 		ownerTarget := target
 		ownerTarget.CreationPolicy = v1beta1.CreationPolicyOwner
 
-		changed, err := reconciler.SyncKubeSecret(ctx, owner, data, ownerTarget)
+		changed, _, err := reconciler.SyncKubeSecret(ctx, owner, data, ownerTarget)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(changed).To(BeTrue())
 
@@ -588,7 +591,7 @@ var _ = Describe("SyncKubeSecret", func() {
 		reconciler := newReconciler()
 		owner := newStaticSecret()
 
-		changed, err := reconciler.SyncKubeSecret(ctx, owner, data, target)
+		changed, _, err := reconciler.SyncKubeSecret(ctx, owner, data, target)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(changed).To(BeTrue())
 
@@ -612,7 +615,7 @@ var _ = Describe("SyncKubeSecret", func() {
 		reconciler := newReconciler(existing)
 		owner := newStaticSecret()
 
-		changed, err := reconciler.SyncKubeSecret(ctx, owner, data, target)
+		changed, _, err := reconciler.SyncKubeSecret(ctx, owner, data, target)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(changed).To(BeTrue())
 
@@ -642,7 +645,7 @@ var _ = Describe("SyncKubeSecret", func() {
 		reconciler := newReconciler(existing)
 		owner := newStaticSecret()
 
-		changed, err := reconciler.SyncKubeSecret(ctx, owner, data, target)
+		changed, _, err := reconciler.SyncKubeSecret(ctx, owner, data, target)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(changed).To(BeFalse())
 
@@ -672,7 +675,7 @@ var _ = Describe("SyncKubeConfigMap", func() {
 		reconciler := newReconciler()
 		owner := newStaticSecret()
 
-		changed, err := reconciler.SyncKubeConfigMap(ctx, owner, data, target)
+		changed, _, err := reconciler.SyncKubeConfigMap(ctx, owner, data, target)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(changed).To(BeTrue())
 
@@ -693,7 +696,7 @@ var _ = Describe("SyncKubeConfigMap", func() {
 		ownerTarget := target
 		ownerTarget.CreationPolicy = v1beta1.CreationPolicyOwner
 
-		changed, err := reconciler.SyncKubeConfigMap(ctx, owner, data, ownerTarget)
+		changed, _, err := reconciler.SyncKubeConfigMap(ctx, owner, data, ownerTarget)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(changed).To(BeTrue())
 
@@ -708,7 +711,7 @@ var _ = Describe("SyncKubeConfigMap", func() {
 		reconciler := newReconciler()
 		owner := newStaticSecret()
 
-		changed, err := reconciler.SyncKubeConfigMap(ctx, owner, data, target)
+		changed, _, err := reconciler.SyncKubeConfigMap(ctx, owner, data, target)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(changed).To(BeTrue())
 
@@ -732,7 +735,7 @@ var _ = Describe("SyncKubeConfigMap", func() {
 		reconciler := newReconciler(existing)
 		owner := newStaticSecret()
 
-		changed, err := reconciler.SyncKubeConfigMap(ctx, owner, data, target)
+		changed, _, err := reconciler.SyncKubeConfigMap(ctx, owner, data, target)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(changed).To(BeTrue())
 
@@ -762,7 +765,7 @@ var _ = Describe("SyncKubeConfigMap", func() {
 		reconciler := newReconciler(existing)
 		owner := newStaticSecret()
 
-		changed, err := reconciler.SyncKubeConfigMap(ctx, owner, data, target)
+		changed, _, err := reconciler.SyncKubeConfigMap(ctx, owner, data, target)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(changed).To(BeFalse())
 	})
@@ -771,7 +774,7 @@ var _ = Describe("SyncKubeConfigMap", func() {
 		reconciler := newReconciler()
 		owner := newStaticSecret()
 
-		_, err := reconciler.SyncKubeConfigMap(ctx, owner, data, target)
+		_, _, err := reconciler.SyncKubeConfigMap(ctx, owner, data, target)
 		Expect(err).NotTo(HaveOccurred())
 
 		created := &corev1.ConfigMap{}
@@ -807,7 +810,7 @@ var _ = Describe("SyncKubeSecret metadata", func() {
 				Annotations: map[string]string{"note": "managed-by-test"},
 			}
 
-			changed, err := reconciler.SyncKubeSecret(ctx, owner, data, target)
+			changed, _, err := reconciler.SyncKubeSecret(ctx, owner, data, target)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(changed).To(BeTrue())
 
@@ -842,7 +845,7 @@ var _ = Describe("SyncKubeSecret metadata", func() {
 				Annotations: map[string]string{"note": "injected"},
 			}
 
-			changed, err := reconciler.SyncKubeSecret(ctx, owner, data, target)
+			changed, _, err := reconciler.SyncKubeSecret(ctx, owner, data, target)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(changed).To(BeTrue())
 
@@ -863,7 +866,7 @@ var _ = Describe("SyncKubeSecret metadata", func() {
 			owner.Labels = map[string]string{"env": "dev"}
 			owner.Annotations = map[string]string{"description": "test secret"}
 
-			changed, err := reconciler.SyncKubeSecret(ctx, owner, data, baseTarget)
+			changed, _, err := reconciler.SyncKubeSecret(ctx, owner, data, baseTarget)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(changed).To(BeTrue())
 
@@ -884,7 +887,7 @@ var _ = Describe("SyncKubeSecret metadata", func() {
 				"custom-annotation":                  "keep-me",
 			}
 
-			changed, err := reconciler.SyncKubeSecret(ctx, owner, data, baseTarget)
+			changed, _, err := reconciler.SyncKubeSecret(ctx, owner, data, baseTarget)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(changed).To(BeTrue())
 
@@ -914,7 +917,7 @@ var _ = Describe("SyncKubeSecret metadata", func() {
 			owner := newStaticSecret()
 			// CRD no longer has the "env" label
 
-			changed, err := reconciler.SyncKubeSecret(ctx, owner, data, baseTarget)
+			changed, _, err := reconciler.SyncKubeSecret(ctx, owner, data, baseTarget)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(changed).To(BeTrue())
 
@@ -942,7 +945,7 @@ var _ = Describe("SyncKubeSecret metadata", func() {
 			reconciler := newReconciler(existing)
 			owner := newStaticSecret()
 
-			changed, err := reconciler.SyncKubeSecret(ctx, owner, data, baseTarget)
+			changed, _, err := reconciler.SyncKubeSecret(ctx, owner, data, baseTarget)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(changed).To(BeFalse())
 
@@ -977,7 +980,7 @@ var _ = Describe("SyncKubeConfigMap metadata", func() {
 			Annotations: map[string]string{"note": "injected"},
 		}
 
-		changed, err := reconciler.SyncKubeConfigMap(ctx, owner, data, target)
+		changed, _, err := reconciler.SyncKubeConfigMap(ctx, owner, data, target)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(changed).To(BeTrue())
 
@@ -993,7 +996,7 @@ var _ = Describe("SyncKubeConfigMap metadata", func() {
 		owner := newStaticSecret()
 		owner.Labels = map[string]string{"env": "staging"}
 
-		changed, err := reconciler.SyncKubeConfigMap(ctx, owner, data, baseTarget)
+		changed, _, err := reconciler.SyncKubeConfigMap(ctx, owner, data, baseTarget)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(changed).To(BeTrue())
 
@@ -1019,7 +1022,7 @@ var _ = Describe("SyncKubeConfigMap metadata", func() {
 		owner := newStaticSecret()
 		owner.Labels = map[string]string{"new-label": "added"}
 
-		changed, err := reconciler.SyncKubeConfigMap(ctx, owner, data, baseTarget)
+		changed, _, err := reconciler.SyncKubeConfigMap(ctx, owner, data, baseTarget)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(changed).To(BeFalse())
 
@@ -1174,7 +1177,7 @@ var _ = Describe("PropagateSecretToWorkloads", func() {
 			dep := newDeployment("web", true, consumesSecret, secretName)
 			reconciler := newReconciler(newTargetSecret(), dep)
 
-			affected, err := reconciler.PropagateSecretToWorkloads(ctx, target)
+			affected, err := reconciler.PropagateSecretToWorkloads(ctx, target, etag)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(affected).To(Equal(1))
 
@@ -1188,7 +1191,7 @@ var _ = Describe("PropagateSecretToWorkloads", func() {
 			ds := newDaemonSet("agent", true, consumesSecret, secretName)
 			reconciler := newReconciler(newTargetSecret(), ds)
 
-			affected, err := reconciler.PropagateSecretToWorkloads(ctx, target)
+			affected, err := reconciler.PropagateSecretToWorkloads(ctx, target, etag)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(affected).To(Equal(1))
 
@@ -1202,7 +1205,7 @@ var _ = Describe("PropagateSecretToWorkloads", func() {
 			ss := newStatefulSet("db", true, consumesSecret, secretName)
 			reconciler := newReconciler(newTargetSecret(), ss)
 
-			affected, err := reconciler.PropagateSecretToWorkloads(ctx, target)
+			affected, err := reconciler.PropagateSecretToWorkloads(ctx, target, etag)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(affected).To(Equal(1))
 
@@ -1216,7 +1219,7 @@ var _ = Describe("PropagateSecretToWorkloads", func() {
 			dep := newDeployment("no-reload", false, consumesSecret, secretName)
 			reconciler := newReconciler(newTargetSecret(), dep)
 
-			affected, err := reconciler.PropagateSecretToWorkloads(ctx, target)
+			affected, err := reconciler.PropagateSecretToWorkloads(ctx, target, etag)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(affected).To(Equal(0))
 
@@ -1229,7 +1232,7 @@ var _ = Describe("PropagateSecretToWorkloads", func() {
 			dep := newDeployment("unrelated", true, consumesNothing, "")
 			reconciler := newReconciler(newTargetSecret(), dep)
 
-			affected, err := reconciler.PropagateSecretToWorkloads(ctx, target)
+			affected, err := reconciler.PropagateSecretToWorkloads(ctx, target, etag)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(affected).To(Equal(0))
 
@@ -1244,7 +1247,7 @@ var _ = Describe("PropagateSecretToWorkloads", func() {
 			dep.Spec.Template.Annotations = map[string]string{annotationKey: etag}
 			reconciler := newReconciler(newTargetSecret(), dep)
 
-			affected, err := reconciler.PropagateSecretToWorkloads(ctx, target)
+			affected, err := reconciler.PropagateSecretToWorkloads(ctx, target, etag)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(affected).To(Equal(1))
 
@@ -1259,7 +1262,7 @@ var _ = Describe("PropagateSecretToWorkloads", func() {
 			ss := newStatefulSet("db", true, consumesSecret, secretName)
 			reconciler := newReconciler(newTargetSecret(), dep, ds, ss)
 
-			affected, err := reconciler.PropagateSecretToWorkloads(ctx, target)
+			affected, err := reconciler.PropagateSecretToWorkloads(ctx, target, etag)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(affected).To(Equal(3))
 
@@ -1283,7 +1286,7 @@ var _ = Describe("PropagateSecretToWorkloads", func() {
 			dep := newDeploymentWithInitContainer("web-init", true, consumesSecret, secretName)
 			reconciler := newReconciler(newTargetSecret(), dep)
 
-			affected, err := reconciler.PropagateSecretToWorkloads(ctx, target)
+			affected, err := reconciler.PropagateSecretToWorkloads(ctx, target, etag)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(affected).To(Equal(1))
 
@@ -1297,7 +1300,7 @@ var _ = Describe("PropagateSecretToWorkloads", func() {
 			ds := newDaemonSetWithInitContainer("agent-init", true, consumesSecret, secretName)
 			reconciler := newReconciler(newTargetSecret(), ds)
 
-			affected, err := reconciler.PropagateSecretToWorkloads(ctx, target)
+			affected, err := reconciler.PropagateSecretToWorkloads(ctx, target, etag)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(affected).To(Equal(1))
 
@@ -1311,7 +1314,7 @@ var _ = Describe("PropagateSecretToWorkloads", func() {
 			ss := newStatefulSetWithInitContainer("db-init", true, consumesSecret, secretName)
 			reconciler := newReconciler(newTargetSecret(), ss)
 
-			affected, err := reconciler.PropagateSecretToWorkloads(ctx, target)
+			affected, err := reconciler.PropagateSecretToWorkloads(ctx, target, etag)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(affected).To(Equal(1))
 
@@ -1321,18 +1324,10 @@ var _ = Describe("PropagateSecretToWorkloads", func() {
 			Expect(updated.Spec.Template.Annotations[annotationKey]).To(Equal(etag))
 		})
 
-		It("returns error when target secret does not exist", func() {
-			reconciler := newReconciler()
-
-			_, err := reconciler.PropagateSecretToWorkloads(ctx, target)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("failed to get target Secret"))
-		})
-
 		It("does nothing when no workloads exist", func() {
 			reconciler := newReconciler(newTargetSecret())
 
-			affected, err := reconciler.PropagateSecretToWorkloads(ctx, target)
+			affected, err := reconciler.PropagateSecretToWorkloads(ctx, target, etag)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(affected).To(Equal(0))
 		})
@@ -1365,7 +1360,7 @@ var _ = Describe("PropagateSecretToWorkloads", func() {
 			dep := newDeployment("web", true, consumesConfigMap, configMapName)
 			reconciler := newReconciler(newTargetConfigMap(), dep)
 
-			affected, err := reconciler.PropagateSecretToWorkloads(ctx, configMapTarget)
+			affected, err := reconciler.PropagateSecretToWorkloads(ctx, configMapTarget, etag)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(affected).To(Equal(1))
 
@@ -1379,7 +1374,7 @@ var _ = Describe("PropagateSecretToWorkloads", func() {
 			ss := newStatefulSet("db", true, consumesConfigMap, configMapName)
 			reconciler := newReconciler(newTargetConfigMap(), ss)
 
-			affected, err := reconciler.PropagateSecretToWorkloads(ctx, configMapTarget)
+			affected, err := reconciler.PropagateSecretToWorkloads(ctx, configMapTarget, etag)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(affected).To(Equal(1))
 
@@ -1393,7 +1388,7 @@ var _ = Describe("PropagateSecretToWorkloads", func() {
 			dep := newDeploymentWithInitContainer("web-init", true, consumesConfigMap, configMapName)
 			reconciler := newReconciler(newTargetConfigMap(), dep)
 
-			affected, err := reconciler.PropagateSecretToWorkloads(ctx, configMapTarget)
+			affected, err := reconciler.PropagateSecretToWorkloads(ctx, configMapTarget, etag)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(affected).To(Equal(1))
 
@@ -1407,7 +1402,7 @@ var _ = Describe("PropagateSecretToWorkloads", func() {
 			ds := newDaemonSetWithInitContainer("agent-init", true, consumesConfigMap, configMapName)
 			reconciler := newReconciler(newTargetConfigMap(), ds)
 
-			affected, err := reconciler.PropagateSecretToWorkloads(ctx, configMapTarget)
+			affected, err := reconciler.PropagateSecretToWorkloads(ctx, configMapTarget, etag)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(affected).To(Equal(1))
 
@@ -1421,7 +1416,7 @@ var _ = Describe("PropagateSecretToWorkloads", func() {
 			ss := newStatefulSetWithInitContainer("db-init", true, consumesConfigMap, configMapName)
 			reconciler := newReconciler(newTargetConfigMap(), ss)
 
-			affected, err := reconciler.PropagateSecretToWorkloads(ctx, configMapTarget)
+			affected, err := reconciler.PropagateSecretToWorkloads(ctx, configMapTarget, etag)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(affected).To(Equal(1))
 
@@ -1435,7 +1430,7 @@ var _ = Describe("PropagateSecretToWorkloads", func() {
 			dep := newDeployment("secret-only", true, consumesSecret, configMapName)
 			reconciler := newReconciler(newTargetConfigMap(), dep)
 
-			affected, err := reconciler.PropagateSecretToWorkloads(ctx, configMapTarget)
+			affected, err := reconciler.PropagateSecretToWorkloads(ctx, configMapTarget, etag)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(affected).To(Equal(0))
 
@@ -1444,12 +1439,91 @@ var _ = Describe("PropagateSecretToWorkloads", func() {
 			Expect(updated.Annotations).NotTo(HaveKey(configMapAnnotationKey))
 		})
 
-		It("returns error when target configmap does not exist", func() {
-			reconciler := newReconciler()
+	})
+})
 
-			_, err := reconciler.PropagateSecretToWorkloads(ctx, configMapTarget)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("failed to get target ConfigMap"))
-		})
+// newStaleCacheReconciler builds a reconciler where Get returns NotFound for
+// a specific namespaced name, simulating the informer cache lag that occurs
+// in a real cluster when a resource is created via the API server but the
+// watch event has not yet reached the local cache.
+func newStaleCacheReconciler(staleNN types.NamespacedName, objs ...client.Object) *svc.InfisicalStaticSecretReconciler {
+	s := newScheme()
+	underlying := fake.NewClientBuilder().WithScheme(s).WithObjects(objs...).Build()
+
+	wrapped := interceptor.NewClient(underlying, interceptor.Funcs{
+		Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			if key == staleNN {
+				return k8Errors.NewNotFound(schema.GroupResource{Resource: "secrets"}, key.Name)
+			}
+			return c.Get(ctx, key, obj, opts...)
+		},
+	})
+
+	return svc.NewReconcilerForTest(wrapped, s)
+}
+
+var _ = Describe("Cache lag bug: SyncKubeSecret then PropagateSecretToWorkloads", func() {
+	ctx := context.Background()
+
+	const namespace = "default"
+	const secretName = "new-target"
+
+	data := map[string][]byte{
+		"KEY": []byte("value"),
+	}
+
+	target := v1beta1.SecretTarget{
+		Name:           secretName,
+		Namespace:      namespace,
+		Kind:           v1beta1.SecretTargetKindSecret,
+		SecretType:     corev1.SecretTypeOpaque,
+		CreationPolicy: v1beta1.CreationPolicyOrphan,
+	}
+
+	It("propagates to workloads even when the informer cache has not caught up", func() {
+		dep := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "web",
+				Namespace: namespace,
+				Annotations: map[string]string{
+					svc.AutoReloadAnnotation: "true",
+				},
+			},
+			Spec: appsv1.DeploymentSpec{
+				Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "web"}},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "web"}},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "main",
+								Image: "busybox",
+								EnvFrom: []corev1.EnvFromSource{
+									{SecretRef: &corev1.SecretEnvSource{
+										LocalObjectReference: corev1.LocalObjectReference{Name: secretName},
+									}},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		staleNN := types.NamespacedName{Name: secretName, Namespace: namespace}
+		reconciler := newStaleCacheReconciler(staleNN, dep)
+		owner := newStaticSecret()
+
+		// Step 1: SyncKubeSecret creates the target Secret. The Create call
+		// bypasses the interceptor (only Get is intercepted), so this succeeds.
+		changed, newEtag, err := reconciler.SyncKubeSecret(ctx, owner, data, target)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(changed).To(BeTrue())
+
+		// Step 2: PropagateSecretToWorkloads should succeed even though the
+		// informer cache has not caught up with the newly created Secret.
+		affected, err := reconciler.PropagateSecretToWorkloads(ctx, target, newEtag)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(affected).To(Equal(1))
 	})
 })


### PR DESCRIPTION
This PR solves a race condition between creating a secret with the new `eTag` and retrieving the tags from the k8s API. Due to the async behavior of k8s API, it might say the secret is not found, causing the race condition.