### PR TITLE
feat: allow source to reference project slug instead of id

### DIFF
--- a/api/v1beta1/infisicalstaticsecret_types.go
+++ b/api/v1beta1/infisicalstaticsecret_types.go
@@ -82,8 +82,11 @@ type SyncOptions struct {
 }
 
 type SecretSource struct {
-	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Optional
 	ProjectId string `json:"projectId"`
+
+	// +kubebuilder:validation:Optional
+	ProjectSlug string `json:"projectSlug"`
 
 	// +kubebuilder:validation:Required
 	EnvironmentSlug string `json:"environmentSlug"`

--- a/config/crd/bases/secrets.infisical.com_infisicalstaticsecrets.yaml
+++ b/config/crd/bases/secrets.infisical.com_infisicalstaticsecrets.yaml
@@ -69,6 +69,8 @@ spec:
                       type: string
                     projectId:
                       type: string
+                    projectSlug:
+                      type: string
                     recursive:
                       type: boolean
                     secretPath:
@@ -79,7 +81,6 @@ spec:
                       type: array
                   required:
                   - environmentSlug
-                  - projectId
                   - secretPath
                   type: object
                 type: array

--- a/helm-charts/secrets-operator/templates/infisicalstaticsecret-crd.yaml
+++ b/helm-charts/secrets-operator/templates/infisicalstaticsecret-crd.yaml
@@ -71,6 +71,8 @@ spec:
                       type: string
                     projectId:
                       type: string
+                    projectSlug:
+                      type: string
                     recursive:
                       type: boolean
                     secretPath:
@@ -81,7 +83,6 @@ spec:
                       type: array
                   required:
                   - environmentSlug
-                  - projectId
                   - secretPath
                   type: object
                 type: array

--- a/internal/api/projects.go
+++ b/internal/api/projects.go
@@ -3,6 +3,7 @@ package api
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/Infisical/infisical/k8-operator/internal/model"
 	"github.com/go-resty/resty/v2"
@@ -13,7 +14,7 @@ func FindProjectBySlug(httpClient *resty.Client, slug string) (model.Project, er
 	response, err := httpClient.
 		R().
 		SetResult(&project).
-		Get(fmt.Sprintf("/api/v1/projects/slug/%s", slug))
+		Get(fmt.Sprintf("/api/v1/projects/slug/%s", url.PathEscape(slug)))
 	if err != nil {
 		return model.Project{}, fmt.Errorf("failed to find project by slug: %w", err)
 	}

--- a/internal/api/projects.go
+++ b/internal/api/projects.go
@@ -1,0 +1,34 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/Infisical/infisical/k8-operator/internal/model"
+	"github.com/go-resty/resty/v2"
+)
+
+func FindProjectBySlug(httpClient *resty.Client, slug string) (model.Project, error) {
+	var project model.Project
+	response, err := httpClient.
+		R().
+		SetResult(&project).
+		Get(fmt.Sprintf("/api/v1/projects/slug/%s", slug))
+	if err != nil {
+		return model.Project{}, fmt.Errorf("failed to find project by slug: %w", err)
+	}
+
+	if response.StatusCode() == http.StatusUnauthorized || response.StatusCode() == http.StatusForbidden {
+		return model.Project{}, fmt.Errorf("%w: status %d", ErrUnauthorized, response.StatusCode())
+	}
+
+	if response.StatusCode() == http.StatusNotFound {
+		return model.Project{}, fmt.Errorf("project with slug %q not found", slug)
+	}
+
+	if response.StatusCode() > 399 {
+		return model.Project{}, fmt.Errorf("failed to find project by slug [status=%d, body=%s]", response.StatusCode(), string(response.Body()))
+	}
+
+	return project, nil
+}

--- a/internal/api/secrets_v4.go
+++ b/internal/api/secrets_v4.go
@@ -27,7 +27,6 @@ func (e *TooManyRequestsError) Error() string {
 
 type ListSecretsRequest struct {
 	ProjectId       string   `json:"workspaceId"`
-	ProjectSlug     string   `json:"projectSlug"`
 	EnvironmentSlug string   `json:"environment"`
 	SecretPath      string   `json:"secretPath"`
 	Tags            []string `json:"tags,omitempty"`

--- a/internal/api/secrets_v4.go
+++ b/internal/api/secrets_v4.go
@@ -27,6 +27,7 @@ func (e *TooManyRequestsError) Error() string {
 
 type ListSecretsRequest struct {
 	ProjectId       string   `json:"workspaceId"`
+	ProjectSlug     string   `json:"projectSlug"`
 	EnvironmentSlug string   `json:"environment"`
 	SecretPath      string   `json:"secretPath"`
 	Tags            []string `json:"tags,omitempty"`

--- a/internal/services/infisicalstaticsecret/reconciler.go
+++ b/internal/services/infisicalstaticsecret/reconciler.go
@@ -165,8 +165,11 @@ func (r *InfisicalStaticSecretReconciler) Validate(infisicalStaticSecret *v1beta
 	}
 
 	for i, source := range spec.Sources {
-		if source.ProjectId == "" {
-			return fmt.Errorf("sources[%d].projectId is required", i)
+		if source.ProjectId == "" && source.ProjectSlug == "" {
+			return fmt.Errorf("either sources[%d].projectId or sources[%d].projectSlug must be set", i, i)
+		}
+		if source.ProjectId != "" && source.ProjectSlug != "" {
+			return fmt.Errorf("you declared both sources[%d].projectId or sources[%d].projectSlug: you should declare only one", i, i)
 		}
 		if source.EnvironmentSlug == "" {
 			return fmt.Errorf("sources[%d].environmentSlug is required", i)
@@ -324,8 +327,17 @@ func (r *InfisicalStaticSecretReconciler) ListSecretsFromSources(ctx context.Con
 	restClient = restClient.SetBaseURL(authenticationResult.Connection.Address())
 	requests := make([]api.ListSecretsRequest, 0, len(infisicalStaticSecret.Spec.Sources))
 	for _, source := range infisicalStaticSecret.Spec.Sources {
+		projectID := source.ProjectId
+		if source.ProjectSlug != "" {
+			project, err := api.FindProjectBySlug(restClient, source.ProjectSlug)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to list secrets: %w", err)
+			}
+			projectID = project.ID
+		}
+
 		requests = append(requests, api.ListSecretsRequest{
-			ProjectId:       source.ProjectId,
+			ProjectId:       projectID,
 			EnvironmentSlug: source.EnvironmentSlug,
 			SecretPath:      source.SecretPath,
 			Tags:            source.TagSlugs,

--- a/internal/services/infisicalstaticsecret/reconciler.go
+++ b/internal/services/infisicalstaticsecret/reconciler.go
@@ -169,7 +169,7 @@ func (r *InfisicalStaticSecretReconciler) Validate(infisicalStaticSecret *v1beta
 			return fmt.Errorf("either sources[%d].projectId or sources[%d].projectSlug must be set", i, i)
 		}
 		if source.ProjectId != "" && source.ProjectSlug != "" {
-			return fmt.Errorf("you declared both sources[%d].projectId or sources[%d].projectSlug: you should declare only one", i, i)
+			return fmt.Errorf("you declared both sources[%d].projectId and sources[%d].projectSlug: you should declare only one", i, i)
 		}
 		if source.EnvironmentSlug == "" {
 			return fmt.Errorf("sources[%d].environmentSlug is required", i)

--- a/internal/services/infisicalstaticsecret/reconciler_test.go
+++ b/internal/services/infisicalstaticsecret/reconciler_test.go
@@ -90,13 +90,24 @@ var _ = Describe("Validate", func() {
 		Expect(err.Error()).To(ContainSubstring("at least one source is required"))
 	})
 
-	It("returns error when a source is missing projectId", func() {
+	It("returns error when a source is missing both projectId and projectSlug", func() {
 		spec := validSpec()
 		spec.Sources[0].ProjectId = ""
+		spec.Sources[0].ProjectSlug = ""
 		obj := &v1beta1.InfisicalStaticSecret{Spec: spec}
 		err := reconciler.Validate(obj)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("sources[0].projectId is required"))
+		Expect(err.Error()).To(ContainSubstring("either sources[0].projectId or sources[0].projectSlug must be set"))
+	})
+
+	It("returns error when a source has both projectId and projectSlug", func() {
+		spec := validSpec()
+		spec.Sources[0].ProjectId = "proj-1"
+		spec.Sources[0].ProjectSlug = "proj-slug"
+		obj := &v1beta1.InfisicalStaticSecret{Spec: spec}
+		err := reconciler.Validate(obj)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("you declared both sources[0].projectId or sources[0].projectSlug"))
 	})
 
 	It("returns error when a source is missing environmentSlug", func() {

--- a/internal/services/infisicalstaticsecret/reconciler_test.go
+++ b/internal/services/infisicalstaticsecret/reconciler_test.go
@@ -107,7 +107,7 @@ var _ = Describe("Validate", func() {
 		obj := &v1beta1.InfisicalStaticSecret{Spec: spec}
 		err := reconciler.Validate(obj)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("you declared both sources[0].projectId or sources[0].projectSlug"))
+		Expect(err.Error()).To(ContainSubstring("you declared both sources[0].projectId and sources[0].projectSlug"))
 	})
 
 	It("returns error when a source is missing environmentSlug", func() {

--- a/test/e2e/e2e_staticsecret_test.go
+++ b/test/e2e/e2e_staticsecret_test.go
@@ -556,6 +556,33 @@ var _ = Describe("InfisicalStaticSecret", Ordered, ContinueOnFailure, func() {
 		Expect(cm.Data).To(HaveKeyWithValue("SHARED_KEY", "shared-val"))
 	})
 
+	It("should sync using project slug instead of project ID", func() {
+		api.CreateFolder(GinkgoT(), project.ID, project.EnvSlug, "/", "slug-test")
+		api.CreateSecret(GinkgoT(), project.ID, project.EnvSlug, "/slug-test", "SLUG_KEY", "slug-value", nil)
+
+		createStaticSecret("e2e-slug-sync", secretsv1beta1.InfisicalStaticSecretSpec{
+			InfisicalAuthRef: authRef,
+			SyncOptions:      &secretsv1beta1.SyncOptions{RefreshInterval: "1h"},
+			Sources: []secretsv1beta1.SecretSource{{
+				ProjectSlug:     project.Slug,
+				EnvironmentSlug: project.EnvSlug,
+				SecretPath:      "/slug-test",
+			}},
+			Targets: []secretsv1beta1.SecretTarget{{
+				Name:           "e2e-slug-synced",
+				Namespace:      testNamespace,
+				Kind:           secretsv1beta1.SecretTargetKindSecret,
+				SecretType:     corev1.SecretTypeOpaque,
+				CreationPolicy: secretsv1beta1.CreationPolicyOwner,
+			}},
+		})
+
+		synced := expectSecret("e2e-slug-synced", "e2e-slug-sync")
+		expectSecretData(synced, map[string]string{
+			"SLUG_KEY": "slug-value",
+		})
+	})
+
 	It("should sync with secret imports", func() {
 		api.CreateFolder(GinkgoT(), project.ID, project.EnvSlug, "/", "shared-lib")
 		api.CreateSecret(GinkgoT(), project.ID, project.EnvSlug, "/shared-lib", "REDIS_URL", "redis://cache:6379", nil)


### PR DESCRIPTION
Now it's possible to reference the `projectSlug` instead of `projectID` in the `InfisicalStaticSecret`'s sources.