### PR TITLE
feat: add examples for InfisicalStaticSecret

### DIFF
--- a/examples/v1beta1/infisicalstaticsecret/aws-iam-auth/infisicalstaticsecret.yaml
+++ b/examples/v1beta1/infisicalstaticsecret/aws-iam-auth/infisicalstaticsecret.yaml
@@ -1,0 +1,49 @@
+# 1. Kubernetes secret holding the machine identity ID
+apiVersion: v1
+kind: Secret
+metadata:
+  name: aws-iam-credentials
+type: Opaque
+stringData:
+  identityId: <your-machine-identity-id> # replace this
+---
+# 2. Connection to the Infisical instance
+apiVersion: secrets.infisical.com/v1beta1
+kind: InfisicalConnection
+metadata:
+  name: my-infisical-connection
+spec:
+  address: https://app.infisical.com
+---
+# 3. Auth using AWS IAM
+apiVersion: secrets.infisical.com/v1beta1
+kind: InfisicalAuth
+metadata:
+  name: my-infisical-auth
+spec:
+  infisicalConnectionRef:
+    name: my-infisical-connection
+  method: aws-iam
+  awsIam:
+    identityIdRef:
+      name: aws-iam-credentials
+      key: identityId
+---
+# 4. Sync secrets into a native Kubernetes Secret
+apiVersion: secrets.infisical.com/v1beta1
+kind: InfisicalStaticSecret
+metadata:
+  name: my-static-secret
+spec:
+  infisicalAuthRef:
+    name: my-infisical-auth
+  syncOptions:
+    refreshInterval: 60s
+  sources:
+    - projectId: <your-project-id> # replace this
+      environmentSlug: dev
+      secretPath: /
+  targets:
+    - name: managed-secret
+      kind: Secret
+      creationPolicy: Owner

--- a/examples/v1beta1/infisicalstaticsecret/aws-iam-auth/infisicalstaticsecret.yaml
+++ b/examples/v1beta1/infisicalstaticsecret/aws-iam-auth/infisicalstaticsecret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: aws-iam-credentials
+  namespace: default
 type: Opaque
 stringData:
   identityId: <your-machine-identity-id> # replace this
@@ -12,6 +13,7 @@ apiVersion: secrets.infisical.com/v1beta1
 kind: InfisicalConnection
 metadata:
   name: my-infisical-connection
+  namespace: default
 spec:
   address: https://app.infisical.com
 ---
@@ -20,13 +22,16 @@ apiVersion: secrets.infisical.com/v1beta1
 kind: InfisicalAuth
 metadata:
   name: my-infisical-auth
+  namespace: default
 spec:
   infisicalConnectionRef:
     name: my-infisical-connection
+    namespace: default
   method: aws-iam
   awsIam:
     identityIdRef:
       name: aws-iam-credentials
+      namespace: default
       key: identityId
 ---
 # 4. Sync secrets into a native Kubernetes Secret
@@ -34,9 +39,11 @@ apiVersion: secrets.infisical.com/v1beta1
 kind: InfisicalStaticSecret
 metadata:
   name: my-static-secret
+  namespace: default
 spec:
   infisicalAuthRef:
     name: my-infisical-auth
+    namespace: default
   syncOptions:
     refreshInterval: 60s
   sources:
@@ -45,5 +52,6 @@ spec:
       secretPath: /
   targets:
     - name: managed-secret
+      namespace: default
       kind: Secret
       creationPolicy: Owner

--- a/examples/v1beta1/infisicalstaticsecret/azure-auth/infisicalstaticsecret.yaml
+++ b/examples/v1beta1/infisicalstaticsecret/azure-auth/infisicalstaticsecret.yaml
@@ -1,0 +1,49 @@
+# 1. Kubernetes secret holding the machine identity ID
+apiVersion: v1
+kind: Secret
+metadata:
+  name: azure-credentials
+type: Opaque
+stringData:
+  identityId: <your-machine-identity-id> # replace this
+---
+# 2. Connection to the Infisical instance
+apiVersion: secrets.infisical.com/v1beta1
+kind: InfisicalConnection
+metadata:
+  name: my-infisical-connection
+spec:
+  address: https://app.infisical.com
+---
+# 3. Auth using Azure managed identity
+apiVersion: secrets.infisical.com/v1beta1
+kind: InfisicalAuth
+metadata:
+  name: my-infisical-auth
+spec:
+  infisicalConnectionRef:
+    name: my-infisical-connection
+  method: azure
+  azure:
+    identityIdRef:
+      name: azure-credentials
+      key: identityId
+---
+# 4. Sync secrets into a native Kubernetes Secret
+apiVersion: secrets.infisical.com/v1beta1
+kind: InfisicalStaticSecret
+metadata:
+  name: my-static-secret
+spec:
+  infisicalAuthRef:
+    name: my-infisical-auth
+  syncOptions:
+    refreshInterval: 60s
+  sources:
+    - projectId: <your-project-id> # replace this
+      environmentSlug: dev
+      secretPath: /
+  targets:
+    - name: managed-secret
+      kind: Secret
+      creationPolicy: Owner

--- a/examples/v1beta1/infisicalstaticsecret/azure-auth/infisicalstaticsecret.yaml
+++ b/examples/v1beta1/infisicalstaticsecret/azure-auth/infisicalstaticsecret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: azure-credentials
+  namespace: default
 type: Opaque
 stringData:
   identityId: <your-machine-identity-id> # replace this
@@ -12,6 +13,7 @@ apiVersion: secrets.infisical.com/v1beta1
 kind: InfisicalConnection
 metadata:
   name: my-infisical-connection
+  namespace: default
 spec:
   address: https://app.infisical.com
 ---
@@ -20,13 +22,16 @@ apiVersion: secrets.infisical.com/v1beta1
 kind: InfisicalAuth
 metadata:
   name: my-infisical-auth
+  namespace: default
 spec:
   infisicalConnectionRef:
     name: my-infisical-connection
+    namespace: default
   method: azure
   azure:
     identityIdRef:
       name: azure-credentials
+      namespace: default
       key: identityId
 ---
 # 4. Sync secrets into a native Kubernetes Secret
@@ -34,9 +39,11 @@ apiVersion: secrets.infisical.com/v1beta1
 kind: InfisicalStaticSecret
 metadata:
   name: my-static-secret
+  namespace: default
 spec:
   infisicalAuthRef:
     name: my-infisical-auth
+    namespace: default
   syncOptions:
     refreshInterval: 60s
   sources:
@@ -45,5 +52,6 @@ spec:
       secretPath: /
   targets:
     - name: managed-secret
+      namespace: default
       kind: Secret
       creationPolicy: Owner

--- a/examples/v1beta1/infisicalstaticsecret/gcp-iam-auth/README.md
+++ b/examples/v1beta1/infisicalstaticsecret/gcp-iam-auth/README.md
@@ -1,0 +1,49 @@
+# GCP IAM Auth - Additional Setup
+
+For details on setting up GCP IAM auth on the Infisical side, see the [GCP IAM Auth guide](https://infisical.com/docs/documentation/platform/identities/gcp-auth#gcp-iam-auth).
+
+GCP IAM auth requires a service account key JSON file to be available inside the operator pod. This means you need to:
+
+1. Create a Kubernetes Secret with your GCP service account key
+2. Mount it into the operator pod via Helm values
+
+## 1. Create the Secret
+
+Download your GCP service account key JSON file from the GCP Console, then run the following command from the same directory where the file was downloaded. Replace the namespace with the one where the operator Helm chart is installed:
+
+```bash
+kubectl create secret generic gcp-sa-key \
+  --from-file=service-account-key.json=./service-account-key.json \
+  -n <operator-namespace>
+```
+
+## 2. Mount it into the operator pod
+
+Add the following to your Helm values:
+
+```yaml
+controllerManager:
+  extraVolumes:
+    - name: gcp-sa-key
+      secret:
+        secretName: gcp-sa-key
+  manager:
+    extraVolumeMounts:
+      - name: gcp-sa-key
+        mountPath: /etc/gcp
+        readOnly: true
+```
+
+Then upgrade the release:
+
+```bash
+helm upgrade <release-name> infisical/secrets-operator -f values.yaml -n <operator-namespace>
+```
+
+## 3. Apply the example
+
+The `serviceAccountKeyFilePath` in `infisicalstaticsecret.yaml` is set to `/etc/gcp/service-account-key.json` to match the mount above. If you used a different mount path or file name, update it accordingly.
+
+```bash
+kubectl apply -f infisicalstaticsecret.yaml
+```

--- a/examples/v1beta1/infisicalstaticsecret/gcp-iam-auth/infisicalstaticsecret.yaml
+++ b/examples/v1beta1/infisicalstaticsecret/gcp-iam-auth/infisicalstaticsecret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: gcp-iam-credentials
+  namespace: default
 type: Opaque
 stringData:
   identityId: <your-machine-identity-id> # replace this
@@ -12,6 +13,7 @@ apiVersion: secrets.infisical.com/v1beta1
 kind: InfisicalConnection
 metadata:
   name: my-infisical-connection
+  namespace: default
 spec:
   address: https://app.infisical.com
 ---
@@ -20,13 +22,16 @@ apiVersion: secrets.infisical.com/v1beta1
 kind: InfisicalAuth
 metadata:
   name: my-infisical-auth
+  namespace: default
 spec:
   infisicalConnectionRef:
     name: my-infisical-connection
+    namespace: default
   method: gcp-iam
   gcpIam:
     identityIdRef:
       name: gcp-iam-credentials
+      namespace: default
       key: identityId
     # Must point to a file inside the operator pod. See README.md for how to
     # create the secret and mount it into the operator via Helm values.
@@ -37,9 +42,11 @@ apiVersion: secrets.infisical.com/v1beta1
 kind: InfisicalStaticSecret
 metadata:
   name: my-static-secret
+  namespace: default
 spec:
   infisicalAuthRef:
     name: my-infisical-auth
+    namespace: default
   syncOptions:
     refreshInterval: 60s
   sources:
@@ -48,5 +55,6 @@ spec:
       secretPath: /
   targets:
     - name: managed-secret
+      namespace: default
       kind: Secret
       creationPolicy: Owner

--- a/examples/v1beta1/infisicalstaticsecret/gcp-iam-auth/infisicalstaticsecret.yaml
+++ b/examples/v1beta1/infisicalstaticsecret/gcp-iam-auth/infisicalstaticsecret.yaml
@@ -1,0 +1,52 @@
+# 1. Kubernetes secret holding the machine identity ID
+apiVersion: v1
+kind: Secret
+metadata:
+  name: gcp-iam-credentials
+type: Opaque
+stringData:
+  identityId: <your-machine-identity-id> # replace this
+---
+# 2. Connection to the Infisical instance
+apiVersion: secrets.infisical.com/v1beta1
+kind: InfisicalConnection
+metadata:
+  name: my-infisical-connection
+spec:
+  address: https://app.infisical.com
+---
+# 3. Auth using GCP IAM with a service account key
+apiVersion: secrets.infisical.com/v1beta1
+kind: InfisicalAuth
+metadata:
+  name: my-infisical-auth
+spec:
+  infisicalConnectionRef:
+    name: my-infisical-connection
+  method: gcp-iam
+  gcpIam:
+    identityIdRef:
+      name: gcp-iam-credentials
+      key: identityId
+    # Must point to a file inside the operator pod. See README.md for how to
+    # create the secret and mount it into the operator via Helm values.
+    serviceAccountKeyFilePath: /etc/gcp/service-account-key.json # replace this
+---
+# 4. Sync secrets into a native Kubernetes Secret
+apiVersion: secrets.infisical.com/v1beta1
+kind: InfisicalStaticSecret
+metadata:
+  name: my-static-secret
+spec:
+  infisicalAuthRef:
+    name: my-infisical-auth
+  syncOptions:
+    refreshInterval: 60s
+  sources:
+    - projectId: <your-project-id> # replace this
+      environmentSlug: dev
+      secretPath: /
+  targets:
+    - name: managed-secret
+      kind: Secret
+      creationPolicy: Owner

--- a/examples/v1beta1/infisicalstaticsecret/gcp-id-token-auth/infisicalstaticsecret.yaml
+++ b/examples/v1beta1/infisicalstaticsecret/gcp-id-token-auth/infisicalstaticsecret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: gcp-id-token-credentials
+  namespace: default
 type: Opaque
 stringData:
   identityId: <your-machine-identity-id> # replace this
@@ -12,6 +13,7 @@ apiVersion: secrets.infisical.com/v1beta1
 kind: InfisicalConnection
 metadata:
   name: my-infisical-connection
+  namespace: default
 spec:
   address: https://app.infisical.com
 ---
@@ -20,13 +22,16 @@ apiVersion: secrets.infisical.com/v1beta1
 kind: InfisicalAuth
 metadata:
   name: my-infisical-auth
+  namespace: default
 spec:
   infisicalConnectionRef:
     name: my-infisical-connection
+    namespace: default
   method: gcp-id-token
   gcpIdToken:
     identityIdRef:
       name: gcp-id-token-credentials
+      namespace: default
       key: identityId
 ---
 # 4. Sync secrets into a native Kubernetes Secret
@@ -34,9 +39,11 @@ apiVersion: secrets.infisical.com/v1beta1
 kind: InfisicalStaticSecret
 metadata:
   name: my-static-secret
+  namespace: default
 spec:
   infisicalAuthRef:
     name: my-infisical-auth
+    namespace: default
   syncOptions:
     refreshInterval: 60s
   sources:
@@ -45,5 +52,6 @@ spec:
       secretPath: /
   targets:
     - name: managed-secret
+      namespace: default
       kind: Secret
       creationPolicy: Owner

--- a/examples/v1beta1/infisicalstaticsecret/gcp-id-token-auth/infisicalstaticsecret.yaml
+++ b/examples/v1beta1/infisicalstaticsecret/gcp-id-token-auth/infisicalstaticsecret.yaml
@@ -1,0 +1,49 @@
+# 1. Kubernetes secret holding the machine identity ID
+apiVersion: v1
+kind: Secret
+metadata:
+  name: gcp-id-token-credentials
+type: Opaque
+stringData:
+  identityId: <your-machine-identity-id> # replace this
+---
+# 2. Connection to the Infisical instance
+apiVersion: secrets.infisical.com/v1beta1
+kind: InfisicalConnection
+metadata:
+  name: my-infisical-connection
+spec:
+  address: https://app.infisical.com
+---
+# 3. Auth using a GCP ID token
+apiVersion: secrets.infisical.com/v1beta1
+kind: InfisicalAuth
+metadata:
+  name: my-infisical-auth
+spec:
+  infisicalConnectionRef:
+    name: my-infisical-connection
+  method: gcp-id-token
+  gcpIdToken:
+    identityIdRef:
+      name: gcp-id-token-credentials
+      key: identityId
+---
+# 4. Sync secrets into a native Kubernetes Secret
+apiVersion: secrets.infisical.com/v1beta1
+kind: InfisicalStaticSecret
+metadata:
+  name: my-static-secret
+spec:
+  infisicalAuthRef:
+    name: my-infisical-auth
+  syncOptions:
+    refreshInterval: 60s
+  sources:
+    - projectId: <your-project-id> # replace this
+      environmentSlug: dev
+      secretPath: /
+  targets:
+    - name: managed-secret
+      kind: Secret
+      creationPolicy: Owner

--- a/examples/v1beta1/infisicalstaticsecret/kubernetes-auth/infisicalstaticsecret.yaml
+++ b/examples/v1beta1/infisicalstaticsecret/kubernetes-auth/infisicalstaticsecret.yaml
@@ -1,0 +1,71 @@
+# 1. Service account used by the operator for token review
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: infisical-service-account
+---
+# 2. Bind the service account to system:auth-delegator so it can
+#    validate tokens via the Kubernetes TokenReview API
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: infisical-service-account-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+  - kind: ServiceAccount
+    name: infisical-service-account
+---
+# 3. Kubernetes secret holding the machine identity ID
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kubernetes-credentials
+type: Opaque
+stringData:
+  identityId: <your-machine-identity-id> # replace this
+---
+# 4. Connection to the Infisical instance
+apiVersion: secrets.infisical.com/v1beta1
+kind: InfisicalConnection
+metadata:
+  name: my-infisical-connection
+spec:
+  address: https://app.infisical.com
+---
+# 5. Auth using a Kubernetes service account token
+apiVersion: secrets.infisical.com/v1beta1
+kind: InfisicalAuth
+metadata:
+  name: my-infisical-auth
+spec:
+  infisicalConnectionRef:
+    name: my-infisical-connection
+  method: kubernetes
+  kubernetes:
+    identityIdRef:
+      name: kubernetes-credentials
+      key: identityId
+    serviceAccountRef:
+      name: infisical-service-account
+---
+# 6. Sync secrets into a native Kubernetes Secret
+apiVersion: secrets.infisical.com/v1beta1
+kind: InfisicalStaticSecret
+metadata:
+  name: my-static-secret
+spec:
+  infisicalAuthRef:
+    name: my-infisical-auth
+  syncOptions:
+    refreshInterval: 60s
+  sources:
+    - projectId: <your-project-id> # replace this
+      environmentSlug: dev
+      secretPath: /
+  targets:
+    - name: managed-secret
+      kind: Secret
+      creationPolicy: Owner

--- a/examples/v1beta1/infisicalstaticsecret/kubernetes-auth/infisicalstaticsecret.yaml
+++ b/examples/v1beta1/infisicalstaticsecret/kubernetes-auth/infisicalstaticsecret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: infisical-service-account
+  namespace: default
 ---
 # 2. Bind the service account to system:auth-delegator so it can
 #    validate tokens via the Kubernetes TokenReview API
@@ -17,12 +18,14 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: infisical-service-account
+    namespace: default
 ---
 # 3. Kubernetes secret holding the machine identity ID
 apiVersion: v1
 kind: Secret
 metadata:
   name: kubernetes-credentials
+  namespace: default
 type: Opaque
 stringData:
   identityId: <your-machine-identity-id> # replace this
@@ -32,6 +35,7 @@ apiVersion: secrets.infisical.com/v1beta1
 kind: InfisicalConnection
 metadata:
   name: my-infisical-connection
+  namespace: default
 spec:
   address: https://app.infisical.com
 ---
@@ -40,25 +44,31 @@ apiVersion: secrets.infisical.com/v1beta1
 kind: InfisicalAuth
 metadata:
   name: my-infisical-auth
+  namespace: default
 spec:
   infisicalConnectionRef:
     name: my-infisical-connection
+    namespace: default
   method: kubernetes
   kubernetes:
     identityIdRef:
       name: kubernetes-credentials
+      namespace: default
       key: identityId
     serviceAccountRef:
       name: infisical-service-account
+      namespace: default
 ---
 # 6. Sync secrets into a native Kubernetes Secret
 apiVersion: secrets.infisical.com/v1beta1
 kind: InfisicalStaticSecret
 metadata:
   name: my-static-secret
+  namespace: default
 spec:
   infisicalAuthRef:
     name: my-infisical-auth
+    namespace: default
   syncOptions:
     refreshInterval: 60s
   sources:
@@ -67,5 +77,6 @@ spec:
       secretPath: /
   targets:
     - name: managed-secret
+      namespace: default
       kind: Secret
       creationPolicy: Owner

--- a/examples/v1beta1/infisicalstaticsecret/ldap-auth/infisicalstaticsecret.yaml
+++ b/examples/v1beta1/infisicalstaticsecret/ldap-auth/infisicalstaticsecret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: ldap-credentials
+  namespace: default
 type: Opaque
 stringData:
   identityId: <your-machine-identity-id> # replace this
@@ -14,6 +15,7 @@ apiVersion: secrets.infisical.com/v1beta1
 kind: InfisicalConnection
 metadata:
   name: my-infisical-connection
+  namespace: default
 spec:
   address: https://app.infisical.com
 ---
@@ -22,19 +24,24 @@ apiVersion: secrets.infisical.com/v1beta1
 kind: InfisicalAuth
 metadata:
   name: my-infisical-auth
+  namespace: default
 spec:
   infisicalConnectionRef:
     name: my-infisical-connection
+    namespace: default
   method: ldap
   ldap:
     identityIdRef:
       name: ldap-credentials
+      namespace: default
       key: identityId
     usernameRef:
       name: ldap-credentials
+      namespace: default
       key: username
     passwordRef:
       name: ldap-credentials
+      namespace: default
       key: password
 ---
 # 4. Sync secrets into a native Kubernetes Secret
@@ -42,9 +49,11 @@ apiVersion: secrets.infisical.com/v1beta1
 kind: InfisicalStaticSecret
 metadata:
   name: my-static-secret
+  namespace: default
 spec:
   infisicalAuthRef:
     name: my-infisical-auth
+    namespace: default
   syncOptions:
     refreshInterval: 60s
   sources:
@@ -53,5 +62,6 @@ spec:
       secretPath: /
   targets:
     - name: managed-secret
+      namespace: default
       kind: Secret
       creationPolicy: Owner

--- a/examples/v1beta1/infisicalstaticsecret/ldap-auth/infisicalstaticsecret.yaml
+++ b/examples/v1beta1/infisicalstaticsecret/ldap-auth/infisicalstaticsecret.yaml
@@ -1,0 +1,57 @@
+# 1. Kubernetes secret holding LDAP credentials and the machine identity ID
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ldap-credentials
+type: Opaque
+stringData:
+  identityId: <your-machine-identity-id> # replace this
+  username: <your-ldap-username> # replace this
+  password: <your-ldap-password> # replace this
+---
+# 2. Connection to the Infisical instance
+apiVersion: secrets.infisical.com/v1beta1
+kind: InfisicalConnection
+metadata:
+  name: my-infisical-connection
+spec:
+  address: https://app.infisical.com
+---
+# 3. Auth using LDAP
+apiVersion: secrets.infisical.com/v1beta1
+kind: InfisicalAuth
+metadata:
+  name: my-infisical-auth
+spec:
+  infisicalConnectionRef:
+    name: my-infisical-connection
+  method: ldap
+  ldap:
+    identityIdRef:
+      name: ldap-credentials
+      key: identityId
+    usernameRef:
+      name: ldap-credentials
+      key: username
+    passwordRef:
+      name: ldap-credentials
+      key: password
+---
+# 4. Sync secrets into a native Kubernetes Secret
+apiVersion: secrets.infisical.com/v1beta1
+kind: InfisicalStaticSecret
+metadata:
+  name: my-static-secret
+spec:
+  infisicalAuthRef:
+    name: my-infisical-auth
+  syncOptions:
+    refreshInterval: 60s
+  sources:
+    - projectId: <your-project-id> # replace this
+      environmentSlug: dev
+      secretPath: /
+  targets:
+    - name: managed-secret
+      kind: Secret
+      creationPolicy: Owner

--- a/examples/v1beta1/infisicalstaticsecret/universal-auth/infisicalstaticsecret.yaml
+++ b/examples/v1beta1/infisicalstaticsecret/universal-auth/infisicalstaticsecret.yaml
@@ -1,0 +1,53 @@
+# 1. Kubernetes secret holding the client credentials
+apiVersion: v1
+kind: Secret
+metadata:
+  name: universal-auth-credentials
+type: Opaque
+stringData:
+  clientId: <your-identity-client-id> # replace this
+  clientSecret: <your-identity-client-secret> # replace this
+---
+# 2. Connection to the Infisical instance
+apiVersion: secrets.infisical.com/v1beta1
+kind: InfisicalConnection
+metadata:
+  name: my-infisical-connection
+spec:
+  address: https://app.infisical.com
+---
+# 3. Auth using Universal Auth credentials
+apiVersion: secrets.infisical.com/v1beta1
+kind: InfisicalAuth
+metadata:
+  name: my-infisical-auth
+spec:
+  infisicalConnectionRef:
+    name: my-infisical-connection
+  method: universal
+  universal:
+    clientIdRef:
+      name: universal-auth-credentials
+      key: clientId
+    clientSecretRef:
+      name: universal-auth-credentials
+      key: clientSecret
+---
+# 4. Sync secrets into a native Kubernetes Secret
+apiVersion: secrets.infisical.com/v1beta1
+kind: InfisicalStaticSecret
+metadata:
+  name: my-static-secret
+spec:
+  infisicalAuthRef:
+    name: my-infisical-auth
+  syncOptions:
+    refreshInterval: 60s
+  sources:
+    - projectId: <your-project-id> # replace this
+      environmentSlug: dev
+      secretPath: /
+  targets:
+    - name: managed-secret
+      kind: Secret
+      creationPolicy: Owner

--- a/examples/v1beta1/infisicalstaticsecret/universal-auth/infisicalstaticsecret.yaml
+++ b/examples/v1beta1/infisicalstaticsecret/universal-auth/infisicalstaticsecret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: universal-auth-credentials
+  namespace: default
 type: Opaque
 stringData:
   clientId: <your-identity-client-id> # replace this
@@ -13,6 +14,7 @@ apiVersion: secrets.infisical.com/v1beta1
 kind: InfisicalConnection
 metadata:
   name: my-infisical-connection
+  namespace: default
 spec:
   address: https://app.infisical.com
 ---
@@ -21,16 +23,20 @@ apiVersion: secrets.infisical.com/v1beta1
 kind: InfisicalAuth
 metadata:
   name: my-infisical-auth
+  namespace: default
 spec:
   infisicalConnectionRef:
     name: my-infisical-connection
+    namespace: default
   method: universal
   universal:
     clientIdRef:
       name: universal-auth-credentials
+      namespace: default
       key: clientId
     clientSecretRef:
       name: universal-auth-credentials
+      namespace: default
       key: clientSecret
 ---
 # 4. Sync secrets into a native Kubernetes Secret
@@ -38,9 +44,11 @@ apiVersion: secrets.infisical.com/v1beta1
 kind: InfisicalStaticSecret
 metadata:
   name: my-static-secret
+  namespace: default
 spec:
   infisicalAuthRef:
     name: my-infisical-auth
+    namespace: default
   syncOptions:
     refreshInterval: 60s
   sources:
@@ -49,5 +57,6 @@ spec:
       secretPath: /
   targets:
     - name: managed-secret
+      namespace: default
       kind: Secret
       creationPolicy: Owner


### PR DESCRIPTION
Adds an `examples` folder containing the full Kubernetes manifest for each auth type.