### PR TITLE
Add commonAnnotations for secret-operator Helm chart

### DIFF
--- a/helm-charts/secrets-operator/templates/deployment.yaml
+++ b/helm-charts/secrets-operator/templates/deployment.yaml
@@ -5,6 +5,10 @@ metadata:
   labels:
     control-plane: controller-manager
   {{- include "secrets-operator.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.controllerManager.replicas }}
   selector:

--- a/helm-charts/secrets-operator/templates/leader-election-rbac.yaml
+++ b/helm-charts/secrets-operator/templates/leader-election-rbac.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "secrets-operator.fullname" . }}-leader-election-role
   labels:
   {{- include "secrets-operator.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 rules:
 - apiGroups:
   - ""
@@ -43,6 +47,10 @@ metadata:
   name: {{ include "secrets-operator.fullname" . }}-leader-election-rolebinding
   labels:
   {{- include "secrets-operator.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/helm-charts/secrets-operator/templates/manager-rbac.yaml
+++ b/helm-charts/secrets-operator/templates/manager-rbac.yaml
@@ -141,6 +141,10 @@ metadata:
   name: {{ include "secrets-operator.fullname" . }}-manager-role
   labels:
   {{- include "secrets-operator.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- include "secrets-operator.managerRules" . }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/helm-charts/secrets-operator/templates/manager-rbac.yaml
+++ b/helm-charts/secrets-operator/templates/manager-rbac.yaml
@@ -107,6 +107,10 @@ metadata:
   namespace: {{ $ns | quote }}
   labels:
   {{- include "secrets-operator.labels" $ | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- include "secrets-operator.managerRules" $ }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -116,6 +120,10 @@ metadata:
   namespace: {{ $ns | quote }}
   labels:
   {{- include "secrets-operator.labels" $ | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -141,6 +149,10 @@ metadata:
   name: {{ include "secrets-operator.fullname" . }}-manager-rolebinding
   labels:
   {{- include "secrets-operator.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/helm-charts/secrets-operator/templates/metrics-auth-rbac.yaml
+++ b/helm-charts/secrets-operator/templates/metrics-auth-rbac.yaml
@@ -11,6 +11,10 @@ metadata:
   {{- end }}
   labels:
   {{- include "secrets-operator.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 rules:
 - apiGroups:
   - authentication.k8s.io
@@ -39,6 +43,10 @@ metadata:
   labels:
 
   {{- include "secrets-operator.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   {{- if and .Values.scopedNamespace .Values.scopedRBAC }}

--- a/helm-charts/secrets-operator/templates/metrics-reader-rbac.yaml
+++ b/helm-charts/secrets-operator/templates/metrics-reader-rbac.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "secrets-operator.fullname" . }}-metrics-reader
   labels:
   {{- include "secrets-operator.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 rules:
 - nonResourceURLs:
   - /metrics

--- a/helm-charts/secrets-operator/templates/metrics-service.yaml
+++ b/helm-charts/secrets-operator/templates/metrics-service.yaml
@@ -5,6 +5,10 @@ metadata:
   labels:
     control-plane: controller-manager
   {{- include "secrets-operator.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.metricsService.type }}
   selector:

--- a/helm-charts/secrets-operator/templates/prometheus-servicemonitor.yaml
+++ b/helm-charts/secrets-operator/templates/prometheus-servicemonitor.yaml
@@ -13,6 +13,10 @@ metadata:
     {{ end }}
     control-plane: controller-manager
     release: prometheus
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   selector:
     matchLabels:

--- a/helm-charts/secrets-operator/templates/serviceaccount.yaml
+++ b/helm-charts/secrets-operator/templates/serviceaccount.yaml
@@ -3,12 +3,18 @@
 {{- end }}
 
 {{- if .Values.controllerManager.serviceAccount.create }}
+
+{{- $annotations := deepCopy (.Values.commonAnnotations | default dict) }}
+{{- $annotations = mergeOverwrite $annotations (.Values.controllerManager.serviceAccount.annotations | default dict) }}
+
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "secrets-operator.serviceAccountName" . }}
   labels:
   {{- include "secrets-operator.labels" . | nindent 4 }}
+  {{- if $annotations }}
   annotations:
-    {{- toYaml .Values.controllerManager.serviceAccount.annotations | nindent 4 }}
+    {{- toYaml $annotations | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/helm-charts/secrets-operator/templates/user-rbac.yaml
+++ b/helm-charts/secrets-operator/templates/user-rbac.yaml
@@ -8,6 +8,10 @@ metadata:
     {{- include "secrets-operator.labels" . | nindent 4 }}
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 rules:
 - apiGroups: ["secrets.infisical.com"]
   resources: ["infisicalsecrets", "infisicalpushsecrets", "infisicaldynamicsecrets", "infisicalstaticsecrets", "clustergenerators"]
@@ -25,6 +29,10 @@ metadata:
     {{- include "secrets-operator.labels" . | nindent 4 }}
     rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 rules:
 - apiGroups: ["secrets.infisical.com"]
   resources: ["infisicalsecrets", "infisicalpushsecrets", "infisicaldynamicsecrets", "infisicalstaticsecrets", "clustergenerators"]

--- a/helm-charts/secrets-operator/values.yaml
+++ b/helm-charts/secrets-operator/values.yaml
@@ -1,3 +1,6 @@
+# -- Annotations that would be applied to all objects created by this chart.
+commonAnnotations: {}
+
 # -- The Infisical API host URL. This is the default host used when no hostAPI is set on the CRD or global ConfigMap.
 hostAPI: "https://app.infisical.com/api"
 


### PR DESCRIPTION
Fixes #99.

Not sure how to do this properly with CRDs though, as they have their own annotations already and I am not sure what's the best way to deal with it:

```
metadata:
  name: infisicalauths.secrets.infisical.com
  annotations:
    controller-gen.kubebuilder.io/version: v0.18.0
  labels:
  {{- include "secrets-operator.labels" . | nindent 4 }}
spec:
```

Need some assistance with what to do here.