### PR TITLE
Add a subdirectories templating function

### DIFF
--- a/helm-charts/secrets-operator/Chart.yaml
+++ b/helm-charts/secrets-operator/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v0.11.7
+version: v0.11.8
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.11.7"
+appVersion: "v0.11.8"

--- a/helm-charts/secrets-operator/values.yaml
+++ b/helm-charts/secrets-operator/values.yaml
@@ -31,7 +31,7 @@ controllerManager:
       readOnlyRootFilesystem: true
     image:
       repository: infisical/kubernetes-operator
-      tag: v0.11.7
+      tag: v0.11.8
     resources:
       limits:
         cpu: 500m

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -40,6 +40,11 @@ func (o V1TemplateOptions) String() string {
 	return o.Value
 }
 
+type V1Subdirectory struct {
+	Name string `json:"name"`
+	Path string `json:"path"`
+}
+
 type Project struct {
 	ID           string `json:"id"`
 	Name         string `json:"name"`

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -40,7 +40,7 @@ func (o V1TemplateOptions) String() string {
 	return o.Value
 }
 
-type V1Subdirectory struct {
+type V1Folder struct {
 	Name string `json:"name"`
 	Path string `json:"path"`
 }

--- a/internal/template/v1/template.go
+++ b/internal/template/v1/template.go
@@ -166,25 +166,25 @@ func newTemplate(name, templateString string, ctx TemplateContext) (*tpl.Templat
 		}
 		return *child.Secret, nil
 	}
-	funcs["subdirectories"] = func(dir string) []model.V1Subdirectory {
+	funcs["foldersIn"] = func(dir string) []model.V1Folder {
 		current := tree
 		for _, seg := range strings.Split(strings.Trim(dir, "/"), "/") {
 			if seg == "" {
 				continue
 			}
 			if current.Children == nil {
-				return []model.V1Subdirectory{}
+				return []model.V1Folder{}
 			}
 			child, exists := current.Children[seg]
 			if !exists {
-				return []model.V1Subdirectory{}
+				return []model.V1Folder{}
 			}
 			current = child
 		}
 
 		basePath := "/" + strings.Trim(dir, "/")
 
-		result := make([]model.V1Subdirectory, 0)
+		result := make([]model.V1Folder, 0)
 		for childName, child := range current.Children {
 			if len(child.Children) == 0 {
 				// A pure leaf is a secret, not a subdirectory. A node may carry
@@ -192,7 +192,7 @@ func newTemplate(name, templateString string, ctx TemplateContext) (*tpl.Templat
 				// a folder segment; such a node is still a valid subdirectory.
 				continue
 			}
-			result = append(result, model.V1Subdirectory{
+			result = append(result, model.V1Folder{
 				Name: childName,
 				Path: strings.TrimRight(basePath, "/") + "/" + childName,
 			})

--- a/internal/template/v1/template.go
+++ b/internal/template/v1/template.go
@@ -186,7 +186,10 @@ func newTemplate(name, templateString string, ctx TemplateContext) (*tpl.Templat
 
 		result := make([]model.V1Subdirectory, 0)
 		for childName, child := range current.Children {
-			if child.Secret != nil {
+			if len(child.Children) == 0 {
+				// A pure leaf is a secret, not a subdirectory. A node may carry
+				// both a Secret and Children when a secret key name collides with
+				// a folder segment; such a node is still a valid subdirectory.
 				continue
 			}
 			result = append(result, model.V1Subdirectory{

--- a/internal/template/v1/template.go
+++ b/internal/template/v1/template.go
@@ -3,6 +3,7 @@ package v1
 import (
 	"bytes"
 	"fmt"
+	"sort"
 	"strings"
 	tpl "text/template"
 
@@ -164,6 +165,38 @@ func newTemplate(name, templateString string, ctx TemplateContext) (*tpl.Templat
 			return model.V1TemplateOptions{}, fmt.Errorf("secretFrom: %q does not resolve to a secret", secretName)
 		}
 		return *child.Secret, nil
+	}
+	funcs["subdirectories"] = func(dir string) []model.V1Subdirectory {
+		current := tree
+		for _, seg := range strings.Split(strings.Trim(dir, "/"), "/") {
+			if seg == "" {
+				continue
+			}
+			if current.Children == nil {
+				return []model.V1Subdirectory{}
+			}
+			child, exists := current.Children[seg]
+			if !exists {
+				return []model.V1Subdirectory{}
+			}
+			current = child
+		}
+
+		basePath := "/" + strings.Trim(dir, "/")
+
+		result := make([]model.V1Subdirectory, 0)
+		for childName, child := range current.Children {
+			if child.Secret != nil {
+				continue
+			}
+			result = append(result, model.V1Subdirectory{
+				Name: childName,
+				Path: strings.TrimRight(basePath, "/") + "/" + childName,
+			})
+		}
+
+		sort.Slice(result, func(i, j int) bool { return result[i].Name < result[j].Name })
+		return result
 	}
 	return tpl.New(name).Funcs(funcs).Parse(templateString)
 }

--- a/internal/template/v1/template_test.go
+++ b/internal/template/v1/template_test.go
@@ -557,4 +557,24 @@ var _ = Describe("RenderPerKeyTemplates with subdirectories", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(data).To(HaveKeyWithValue("dirs", []byte("[]")))
 	})
+
+	It("includes a folder whose name collides with a secret key at the same path", func() {
+		// A root secret key "db" and a "/db" folder produce a single tree node
+		// carrying both a Secret and Children. It must still be listed as a subdirectory.
+		collisionCtx := v1.NewTemplateContext(
+			[]api.Secret{
+				{SecretKey: "db", SecretValue: "some-value", SecretPath: "/"},
+				{SecretKey: "PASSWORD", SecretValue: "secret", SecretPath: "/db"},
+			},
+			nil,
+		)
+
+		tmpls := map[string]string{
+			"dirs": `{{ range subdirectories "/" }}{{ .Name }}={{ .Path }},{{ end }}`,
+		}
+
+		data, err := v1.RenderPerKeyTemplates(tmpls, collisionCtx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(data).To(HaveKeyWithValue("dirs", []byte("db=/db,")))
+	})
 })

--- a/internal/template/v1/template_test.go
+++ b/internal/template/v1/template_test.go
@@ -504,3 +504,57 @@ other_path: "{{ (secretFrom "/folder/other" "API_KEY").SecretPath }}"`
 		Expect(err.Error()).To(ContainSubstring("wrong number of args"))
 	})
 })
+
+var _ = Describe("RenderPerKeyTemplates with subdirectories", func() {
+
+	It("lists immediate subdirectory names under a path", func() {
+		tmpls := map[string]string{
+			"dirs": `{{ range subdirectories "/folder" }}{{ .Name }},{{ end }}`,
+		}
+
+		data, err := v1.RenderPerKeyTemplates(tmpls, subfolderCtx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(data).To(HaveKeyWithValue("dirs", []byte("other,subfolder,")))
+	})
+
+	It("exposes .Name and .Path for each subdirectory", func() {
+		tmpls := map[string]string{
+			"detail": `{{ range subdirectories "/folder" }}{{ .Name }}|{{ .Path }};{{ end }}`,
+		}
+
+		data, err := v1.RenderPerKeyTemplates(tmpls, subfolderCtx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(data).To(HaveKeyWithValue("detail", []byte("other|/folder/other;subfolder|/folder/subfolder;")))
+	})
+
+	It("lists top-level folders when passed the root path", func() {
+		tmpls := map[string]string{
+			"dirs": `{{ range subdirectories "/" }}{{ .Name }}={{ .Path }},{{ end }}`,
+		}
+
+		data, err := v1.RenderPerKeyTemplates(tmpls, subfolderCtx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(data).To(HaveKeyWithValue("dirs", []byte("folder=/folder,")))
+	})
+
+	It("returns an empty list without error for a path not in the tree", func() {
+		tmpls := map[string]string{
+			"dirs": `[{{ range subdirectories "/missing" }}{{ .Name }}{{ end }}]`,
+		}
+
+		data, err := v1.RenderPerKeyTemplates(tmpls, subfolderCtx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(data).To(HaveKeyWithValue("dirs", []byte("[]")))
+	})
+
+	It("does not include secret leaves, only folder nodes", func() {
+		tmpls := map[string]string{
+			// /folder/subfolder holds only secrets (DB_HOST, DB_PORT, API_KEY) and no subdirectories.
+			"dirs": `[{{ range subdirectories "/folder/subfolder" }}{{ .Name }}{{ end }}]`,
+		}
+
+		data, err := v1.RenderPerKeyTemplates(tmpls, subfolderCtx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(data).To(HaveKeyWithValue("dirs", []byte("[]")))
+	})
+})

--- a/internal/template/v1/template_test.go
+++ b/internal/template/v1/template_test.go
@@ -509,7 +509,7 @@ var _ = Describe("RenderPerKeyTemplates with subdirectories", func() {
 
 	It("lists immediate subdirectory names under a path", func() {
 		tmpls := map[string]string{
-			"dirs": `{{ range subdirectories "/folder" }}{{ .Name }},{{ end }}`,
+			"dirs": `{{ range foldersIn "/folder" }}{{ .Name }},{{ end }}`,
 		}
 
 		data, err := v1.RenderPerKeyTemplates(tmpls, subfolderCtx)
@@ -519,7 +519,7 @@ var _ = Describe("RenderPerKeyTemplates with subdirectories", func() {
 
 	It("exposes .Name and .Path for each subdirectory", func() {
 		tmpls := map[string]string{
-			"detail": `{{ range subdirectories "/folder" }}{{ .Name }}|{{ .Path }};{{ end }}`,
+			"detail": `{{ range foldersIn "/folder" }}{{ .Name }}|{{ .Path }};{{ end }}`,
 		}
 
 		data, err := v1.RenderPerKeyTemplates(tmpls, subfolderCtx)
@@ -529,7 +529,7 @@ var _ = Describe("RenderPerKeyTemplates with subdirectories", func() {
 
 	It("lists top-level folders when passed the root path", func() {
 		tmpls := map[string]string{
-			"dirs": `{{ range subdirectories "/" }}{{ .Name }}={{ .Path }},{{ end }}`,
+			"dirs": `{{ range foldersIn "/" }}{{ .Name }}={{ .Path }},{{ end }}`,
 		}
 
 		data, err := v1.RenderPerKeyTemplates(tmpls, subfolderCtx)
@@ -539,7 +539,7 @@ var _ = Describe("RenderPerKeyTemplates with subdirectories", func() {
 
 	It("returns an empty list without error for a path not in the tree", func() {
 		tmpls := map[string]string{
-			"dirs": `[{{ range subdirectories "/missing" }}{{ .Name }}{{ end }}]`,
+			"dirs": `[{{ range foldersIn "/missing" }}{{ .Name }}{{ end }}]`,
 		}
 
 		data, err := v1.RenderPerKeyTemplates(tmpls, subfolderCtx)
@@ -550,7 +550,7 @@ var _ = Describe("RenderPerKeyTemplates with subdirectories", func() {
 	It("does not include secret leaves, only folder nodes", func() {
 		tmpls := map[string]string{
 			// /folder/subfolder holds only secrets (DB_HOST, DB_PORT, API_KEY) and no subdirectories.
-			"dirs": `[{{ range subdirectories "/folder/subfolder" }}{{ .Name }}{{ end }}]`,
+			"dirs": `[{{ range foldersIn "/folder/subfolder" }}{{ .Name }}{{ end }}]`,
 		}
 
 		data, err := v1.RenderPerKeyTemplates(tmpls, subfolderCtx)
@@ -570,7 +570,7 @@ var _ = Describe("RenderPerKeyTemplates with subdirectories", func() {
 		)
 
 		tmpls := map[string]string{
-			"dirs": `{{ range subdirectories "/" }}{{ .Name }}={{ .Path }},{{ end }}`,
+			"dirs": `{{ range foldersIn "/" }}{{ .Name }}={{ .Path }},{{ end }}`,
 		}
 
 		data, err := v1.RenderPerKeyTemplates(tmpls, collisionCtx)


### PR DESCRIPTION
Adds a subdirectories templating function which enables ConfigMap templating to be highly dynamic based on the structure of the project it's pulling from.

This is useeful when a directory has a set of homogeneous subdirectories. (e.g. subdirectories a and b both have the same set of secrets, and the subdirectory names a and b may not be known).