### PR TITLE
improvement(k8-operator): add version to User-Agent header

### DIFF
--- a/.github/workflows/release_docker_k8_operator.yaml
+++ b/.github/workflows/release_docker_k8_operator.yaml
@@ -51,6 +51,8 @@ jobs:
                   context: .
                   push: true
                   platforms: linux/amd64,linux/arm64
+                  build-args: |
+                      VERSION=${{ steps.extract_version.outputs.version }}
                   tags: |
                       infisical/kubernetes-operator:latest
                       infisical/kubernetes-operator:${{ steps.extract_version.outputs.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@
 FROM golang:1.25 AS builder
 ARG TARGETOS
 ARG TARGETARCH
+# Operator version, injected into the binary as its self-reported version and
+# User-Agent. Defaults to "dev"; CI passes the release tag via --build-arg VERSION=...
+ARG VERSION=dev
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -21,7 +24,7 @@ COPY internal/ internal/
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -ldflags="-X github.com/Infisical/infisical/k8-operator/internal/util.Version=${VERSION}" -a -o manager cmd/main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,11 @@
 VERSION ?= latest
 IMG ?= infisical/kubernetes-operator:${VERSION} # ${VERSION} will be replaced by the version in the CI step
 
+# OPERATOR_VERSION is injected into the binary as its self-reported version and
+# User-Agent (util.Version). Defaults to "dev" for local builds; CI/Docker overrides it.
+OPERATOR_VERSION ?= dev
+LDFLAGS ?= -X github.com/Infisical/infisical/k8-operator/internal/util.Version=$(OPERATOR_VERSION)
+
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin
@@ -133,7 +138,7 @@ lint-config: golangci-lint ## Verify golangci-lint linter configuration
 
 .PHONY: build
 build: manifests generate fmt vet ## Build manager binary.
-	go build -o bin/manager cmd/main.go
+	go build -ldflags="$(LDFLAGS)" -o bin/manager cmd/main.go
 
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.
@@ -144,7 +149,7 @@ run: manifests generate fmt vet ## Run a controller from your host.
 # More info: https://docs.docker.com/develop/develop-images/build_enhancements/
 .PHONY: docker-build
 docker-build: ## Build docker image with the manager.
-	$(CONTAINER_TOOL) build -t ${IMG} .
+	$(CONTAINER_TOOL) build --build-arg VERSION=$(OPERATOR_VERSION) -t ${IMG} .
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.
@@ -163,7 +168,7 @@ docker-buildx: ## Build and push docker image for the manager for cross-platform
 	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
 	- $(CONTAINER_TOOL) buildx create --name infisical-operator-builder
 	$(CONTAINER_TOOL) buildx use infisical-operator-builder
-	- $(CONTAINER_TOOL) buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross .
+	- $(CONTAINER_TOOL) buildx build --build-arg VERSION=$(OPERATOR_VERSION) --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross .
 	- $(CONTAINER_TOOL) buildx rm infisical-operator-builder
 	rm Dockerfile.cross
 

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,13 @@
 VERSION ?= latest
 IMG ?= infisical/kubernetes-operator:${VERSION} # ${VERSION} will be replaced by the version in the CI step
 
-# OPERATOR_VERSION is injected into the binary as its self-reported version and
-# User-Agent (util.Version). Defaults to "dev" for local builds; CI/Docker overrides it.
+# Version embedded in the local `build` binary (util.Version, used in the
+# User-Agent). Docker targets embed the image tag ($(VERSION)) instead.
 OPERATOR_VERSION ?= dev
-LDFLAGS ?= -X github.com/Infisical/infisical/k8-operator/internal/util.Version=$(OPERATOR_VERSION)
+# VERSION_LDFLAGS is always applied at build time so the version is never dropped;
+# LDFLAGS is for extra caller-supplied flags and is appended alongside it.
+VERSION_LDFLAGS := -X github.com/Infisical/infisical/k8-operator/internal/util.Version=$(OPERATOR_VERSION)
+LDFLAGS ?=
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -138,7 +141,7 @@ lint-config: golangci-lint ## Verify golangci-lint linter configuration
 
 .PHONY: build
 build: manifests generate fmt vet ## Build manager binary.
-	go build -ldflags="$(LDFLAGS)" -o bin/manager cmd/main.go
+	go build -ldflags="$(VERSION_LDFLAGS) $(LDFLAGS)" -o bin/manager cmd/main.go
 
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.
@@ -149,7 +152,7 @@ run: manifests generate fmt vet ## Run a controller from your host.
 # More info: https://docs.docker.com/develop/develop-images/build_enhancements/
 .PHONY: docker-build
 docker-build: ## Build docker image with the manager.
-	$(CONTAINER_TOOL) build --build-arg VERSION=$(OPERATOR_VERSION) -t ${IMG} .
+	$(CONTAINER_TOOL) build --build-arg VERSION=$(VERSION) -t ${IMG} .
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.
@@ -168,7 +171,7 @@ docker-buildx: ## Build and push docker image for the manager for cross-platform
 	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
 	- $(CONTAINER_TOOL) buildx create --name infisical-operator-builder
 	$(CONTAINER_TOOL) buildx use infisical-operator-builder
-	- $(CONTAINER_TOOL) buildx build --build-arg VERSION=$(OPERATOR_VERSION) --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross .
+	- $(CONTAINER_TOOL) buildx build --build-arg VERSION=$(VERSION) --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross .
 	- $(CONTAINER_TOOL) buildx rm infisical-operator-builder
 	rm Dockerfile.cross
 

--- a/internal/services/infisicalconnection/handler.go
+++ b/internal/services/infisicalconnection/handler.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/Infisical/infisical/k8-operator/api/v1beta1"
-	"github.com/Infisical/infisical/k8-operator/internal/constants"
 	"github.com/Infisical/infisical/k8-operator/internal/model"
 	"github.com/Infisical/infisical/k8-operator/internal/util"
 	"github.com/go-logr/logr"
@@ -98,7 +97,7 @@ func (h *InfisicalConnectionHandler) TestConnection(ctx context.Context, infisic
 
 	httpClient := resty.New().
 		SetBaseURL(hostURL).
-		SetHeader("User-Agent", constants.USER_AGENT_NAME).
+		SetHeader("User-Agent", util.UserAgent()).
 		SetTimeout(30 * time.Second)
 
 	if tlsConfig := infisicalConnection.Spec.TLS; tlsConfig != nil && tlsConfig.CaCertificate != nil {

--- a/internal/services/infisicaldynamicsecret/reconciler.go
+++ b/internal/services/infisicaldynamicsecret/reconciler.go
@@ -120,7 +120,7 @@ func (r *InfisicalDynamicSecretReconciler) getResourceVariables(infisicalDynamic
 		client := infisicalSdk.NewInfisicalClient(ctx, infisicalSdk.Config{
 			SiteUrl:       config.API_HOST_URL,
 			CaCertificate: config.API_CA_CERTIFICATE,
-			UserAgent:     constants.USER_AGENT_NAME,
+			UserAgent:     util.UserAgent(),
 			LogWriter:     config.API_LOG_WRITER,
 		})
 

--- a/internal/services/infisicalpushsecret/reconciler.go
+++ b/internal/services/infisicalpushsecret/reconciler.go
@@ -40,7 +40,7 @@ func (r *InfisicalPushSecretReconciler) getResourceVariables(infisicalPushSecret
 		client := infisicalSdk.NewInfisicalClient(ctx, infisicalSdk.Config{
 			SiteUrl:       config.API_HOST_URL,
 			CaCertificate: config.API_CA_CERTIFICATE,
-			UserAgent:     constants.USER_AGENT_NAME,
+			UserAgent:     util.UserAgent(),
 			LogWriter:     config.API_LOG_WRITER,
 		})
 

--- a/internal/services/infisicalsecret/reconciler.go
+++ b/internal/services/infisicalsecret/reconciler.go
@@ -625,7 +625,7 @@ func (r *InfisicalSecretReconciler) getResourceVariables(infisicalSecret v1alpha
 		client := infisicalSdk.NewInfisicalClient(ctx, infisicalSdk.Config{
 			SiteUrl:       config.API_HOST_URL,
 			CaCertificate: config.API_CA_CERTIFICATE,
-			UserAgent:     constants.USER_AGENT_NAME,
+			UserAgent:     util.UserAgent(),
 			LogWriter:     config.API_LOG_WRITER,
 		})
 

--- a/internal/util/helpers.go
+++ b/internal/util/helpers.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/Infisical/infisical/k8-operator/internal/config"
-	"github.com/Infisical/infisical/k8-operator/internal/constants"
 	"github.com/Infisical/infisical/k8-operator/internal/model"
 	"github.com/go-resty/resty/v2"
 )
@@ -78,7 +77,7 @@ func CreateRestyClient(options model.CreateRestyClientOptions) (*resty.Client, e
 	for key, value := range options.Headers {
 		httpClient.SetHeader(key, value)
 	}
-	httpClient.SetHeader("User-Agent", constants.USER_AGENT_NAME)
+	httpClient.SetHeader("User-Agent", UserAgent())
 
 	caCertificate := cmp.Or(config.API_CA_CERTIFICATE, options.CaCertificate)
 	if caCertificate != "" {

--- a/internal/util/version.go
+++ b/internal/util/version.go
@@ -1,0 +1,20 @@
+package util
+
+import (
+	"fmt"
+
+	"github.com/Infisical/infisical/k8-operator/internal/constants"
+)
+
+// Version is the operator version. It defaults to "dev" for local builds and is
+// overridden at build time via:
+//
+//	-ldflags "-X github.com/Infisical/infisical/k8-operator/internal/util.Version=<version>"
+var Version = "dev"
+
+// UserAgent returns the standard product/version User-Agent token sent on every
+// outbound request from the operator, e.g. "k8-operator/v0.11.4". This is the
+// single source of truth for the User-Agent string.
+func UserAgent() string {
+	return fmt.Sprintf("%s/%s", constants.USER_AGENT_NAME, Version)
+}


### PR DESCRIPTION
## Context

Outbound Infisical API requests from the operator used a static `User-Agent` of `k8-operator`, with no way to tell which release was running. That makes it harder to correlate server-side logs, support tickets, and usage metrics with a specific operator version.

This change injects the operator version at build time and centralizes User-Agent construction in `util.UserAgent()`, which returns `k8-operator/<version>` (e.g. `k8-operator/v0.11.4`). All reconcilers, the connection handler, and the shared Resty client helper now use that function instead of the bare product name constant.

Release builds pass the version via `-ldflags` (`util.Version`); local/Makefile/Docker builds default to `dev`. The Docker release workflow passes `VERSION` as a build arg so published images report the release tag.

## Steps to verify the change

1. Build locally with an injected version:
   ```bash
   make build OPERATOR_VERSION=v0.11.4-test
   ```
2. Run the operator (or any code path that calls Infisical) and confirm outbound requests include `User-Agent: k8-operator/v0.11.4-test` (e.g. via Infisical server access logs or a proxy).
3. Build without `VERSION` and confirm the header is `k8-operator/dev`:
   ```bash
   make build
   ```