### PR TITLE
fix: keep managed-secret annotation key within Kubernetes 63 byte limit

### DIFF
--- a/internal/controllerhelpers/controllerhelpers.go
+++ b/internal/controllerhelpers/controllerhelpers.go
@@ -191,7 +191,7 @@ func IsStatefulSetUsingManagedSecret(statefulSet v1.StatefulSet, managedSecret v
 // This function ensures that a deployment is in sync with a Kubernetes secret by comparing their versions.
 // If the version of the secret is different from the version annotation on the deployment, the annotation is updated to trigger a restart of the deployment.
 func ReconcileDeployment(ctx context.Context, client controllerClient.Client, logger logr.Logger, deployment v1.Deployment, secret corev1.Secret) error {
-	annotationKey := fmt.Sprintf("%s.%s", DEPLOYMENT_SECRET_NAME_ANNOTATION_PREFIX, secret.Name)
+	annotationKey := util.BuildManagedSecretAnnotationKey(DEPLOYMENT_SECRET_NAME_ANNOTATION_PREFIX, secret.Name)
 	annotationValue := secret.Annotations[constants.SECRET_VERSION_ANNOTATION]
 
 	if deployment.Annotations[annotationKey] == annotationValue &&
@@ -216,7 +216,7 @@ func ReconcileDeployment(ctx context.Context, client controllerClient.Client, lo
 }
 
 func ReconcileDaemonSet(ctx context.Context, client controllerClient.Client, logger logr.Logger, daemonSet v1.DaemonSet, secret corev1.Secret) error {
-	annotationKey := fmt.Sprintf("%s.%s", DEPLOYMENT_SECRET_NAME_ANNOTATION_PREFIX, secret.Name)
+	annotationKey := util.BuildManagedSecretAnnotationKey(DEPLOYMENT_SECRET_NAME_ANNOTATION_PREFIX, secret.Name)
 	annotationValue := secret.Annotations[constants.SECRET_VERSION_ANNOTATION]
 
 	if daemonSet.Annotations[annotationKey] == annotationValue &&
@@ -241,7 +241,7 @@ func ReconcileDaemonSet(ctx context.Context, client controllerClient.Client, log
 }
 
 func ReconcileStatefulSet(ctx context.Context, client controllerClient.Client, logger logr.Logger, statefulSet v1.StatefulSet, secret corev1.Secret) error {
-	annotationKey := fmt.Sprintf("%s.%s", DEPLOYMENT_SECRET_NAME_ANNOTATION_PREFIX, secret.Name)
+	annotationKey := util.BuildManagedSecretAnnotationKey(DEPLOYMENT_SECRET_NAME_ANNOTATION_PREFIX, secret.Name)
 	annotationValue := secret.Annotations[constants.SECRET_VERSION_ANNOTATION]
 
 	if statefulSet.Annotations[annotationKey] == annotationValue &&

--- a/internal/services/infisicalstaticsecret/reconciler.go
+++ b/internal/services/infisicalstaticsecret/reconciler.go
@@ -32,8 +32,9 @@ import (
 )
 
 const (
-	AutoReloadAnnotation       = "secrets.infisical.com/auto-reload"
-	ManagedSecretAnnotationFmt = "secrets.infisical.com/managed-secret.%s"
+	AutoReloadAnnotation          = "secrets.infisical.com/auto-reload"
+	ManagedSecretAnnotationFmt    = "secrets.infisical.com/managed-secret.%s"
+	ManagedSecretAnnotationPrefix = "secrets.infisical.com/managed-secret"
 )
 
 var systemAnnotationPrefixes = []string{"kubectl.kubernetes.io/", "kubernetes.io/", "k8s.io/", "helm.sh/"}
@@ -573,7 +574,7 @@ func (r *InfisicalStaticSecretReconciler) SyncKubeConfigMap(ctx context.Context,
 }
 
 func (r *InfisicalStaticSecretReconciler) PropagateSecretToWorkloads(ctx context.Context, target v1beta1.SecretTarget, etag string) (int, error) {
-	annotationKey := fmt.Sprintf(ManagedSecretAnnotationFmt, target.Name)
+	annotationKey := util.BuildManagedSecretAnnotationKey(ManagedSecretAnnotationPrefix, target.Name)
 
 	workloads, err := r.listWorkloadsConsumingTarget(ctx, target)
 	if err != nil {

--- a/internal/util/annotations.go
+++ b/internal/util/annotations.go
@@ -1,0 +1,53 @@
+package util
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+)
+
+// AnnotationNameMaxLength is the maximum length Kubernetes permits for the name portion of an
+// annotation key, meaning everything after the optional "<dns-subdomain>/" prefix.
+const AnnotationNameMaxLength = 63
+
+// annotationHashLength is the number of hex characters kept from the digest used to
+// disambiguate truncated names.
+const annotationHashLength = 8
+
+// BuildManagedSecretAnnotationKey returns the annotation key used to track a managed secret on a
+// workload, shortening it deterministically when the name portion of the key would exceed
+// Kubernetes' 63 byte limit.
+//
+// keyPrefix is the full annotation prefix, for example
+// "secrets.infisical.com/managed-secret". Only the portion after the "/" counts towards the
+// limit, so the DNS subdomain is excluded from the length calculation.
+//
+// Names that already fit are returned unchanged, so existing workloads keep their current
+// annotation. Longer names are truncated and suffixed with a short digest of the full secret
+// name, which keeps the key unique, stable across reconciles, and still recognizable.
+func BuildManagedSecretAnnotationKey(keyPrefix string, secretName string) string {
+	// Annotation keys are "<dns-subdomain>/<name>"; only <name> is bounded by the 63 byte limit.
+	domain, namePrefix := "", keyPrefix
+	if idx := strings.Index(keyPrefix, "/"); idx != -1 {
+		domain, namePrefix = keyPrefix[:idx+1], keyPrefix[idx+1:]
+	}
+
+	if len(namePrefix)+1+len(secretName) <= AnnotationNameMaxLength {
+		return fmt.Sprintf("%s.%s", keyPrefix, secretName)
+	}
+
+	sum := sha256.Sum256([]byte(secretName))
+	digest := hex.EncodeToString(sum[:])[:annotationHashLength]
+	suffix := "-" + digest
+
+	// Room left for the secret name once the name prefix, separator and digest are accounted for.
+	available := AnnotationNameMaxLength - len(namePrefix) - 1 - len(suffix)
+	if available < 1 {
+		// The prefix alone leaves no room for a name, so fall back to a digest-only name that
+		// still fits. Truncating the prefix would risk colliding with other operator keys.
+		return domain + digest
+	}
+
+	return fmt.Sprintf("%s.%s%s", keyPrefix, secretName[:available], suffix)
+}

--- a/internal/util/annotations_test.go
+++ b/internal/util/annotations_test.go
@@ -1,0 +1,71 @@
+package util_test
+
+import (
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/Infisical/infisical/k8-operator/internal/util"
+)
+
+const managedSecretPrefix = "secrets.infisical.com/managed-secret"
+
+// namePart returns the portion of an annotation key that is bounded by the 63 byte limit.
+func namePart(key string) string {
+	if idx := strings.Index(key, "/"); idx != -1 {
+		return key[idx+1:]
+	}
+	return key
+}
+
+var _ = Describe("BuildManagedSecretAnnotationKey", func() {
+
+	It("leaves short names unchanged so existing workloads keep their annotation", func() {
+		key := util.BuildManagedSecretAnnotationKey(managedSecretPrefix, "my-app-secrets")
+		Expect(key).To(Equal("secrets.infisical.com/managed-secret.my-app-secrets"))
+	})
+
+	It("leaves a name that exactly fills the limit unchanged", func() {
+		// len("managed-secret.") is 15, so a 48 byte secret name yields exactly 63 bytes.
+		secretName := strings.Repeat("a", 48)
+		key := util.BuildManagedSecretAnnotationKey(managedSecretPrefix, secretName)
+		Expect(namePart(key)).To(HaveLen(util.AnnotationNameMaxLength))
+		Expect(key).To(HaveSuffix(secretName))
+	})
+
+	DescribeTable("keeps the name part within the Kubernetes limit",
+		func(secretName string) {
+			key := util.BuildManagedSecretAnnotationKey(managedSecretPrefix, secretName)
+			Expect(len(namePart(key))).To(BeNumerically("<=", util.AnnotationNameMaxLength))
+		},
+		Entry("one byte over the limit", strings.Repeat("a", 49)),
+		Entry("long service name with an environment suffix",
+			"some-service-with-a-fairly-long-name-staging-secrets"),
+		Entry("long service name with a multi-part secret suffix",
+			"another-service-with-a-long-name-staging-common-aws-secrets"),
+		Entry("maximum length resource name", strings.Repeat("a", 253)),
+	)
+
+	It("produces stable keys across repeated calls", func() {
+		secretName := "some-service-with-a-fairly-long-name-staging-secrets"
+		first := util.BuildManagedSecretAnnotationKey(managedSecretPrefix, secretName)
+		second := util.BuildManagedSecretAnnotationKey(managedSecretPrefix, secretName)
+		Expect(first).To(Equal(second))
+	})
+
+	It("distinguishes names that share a truncated prefix", func() {
+		base := strings.Repeat("a", 60)
+		first := util.BuildManagedSecretAnnotationKey(managedSecretPrefix, base+"-one-secrets")
+		second := util.BuildManagedSecretAnnotationKey(managedSecretPrefix, base+"-two-secrets")
+		Expect(first).ToNot(Equal(second))
+		Expect(len(namePart(first))).To(BeNumerically("<=", util.AnnotationNameMaxLength))
+		Expect(len(namePart(second))).To(BeNumerically("<=", util.AnnotationNameMaxLength))
+	})
+
+	It("stays valid when the prefix alone leaves no room for a name", func() {
+		longPrefix := "secrets.infisical.com/" + strings.Repeat("p", 62)
+		key := util.BuildManagedSecretAnnotationKey(longPrefix, "some-secret-name")
+		Expect(len(namePart(key))).To(BeNumerically("<=", util.AnnotationNameMaxLength))
+	})
+})


### PR DESCRIPTION
## Problem

The operator tracks managed secrets on workloads using an annotation key of the form
`secrets.infisical.com/managed-secret.<secretName>`.

Kubernetes limits the *name* portion of an annotation key (everything after the `/`) to 63
bytes. The `managed-secret.` prefix consumes 15 of those, so any managed secret whose name
exceeds **48 bytes** produces an invalid key and the workload update fails permanently.

The effect is that affected Deployments, DaemonSets and StatefulSets **never auto-reload on
secret rotation** and can serve stale secrets indefinitely. It is silent from the user's point
of view: the secret itself syncs correctly, and only an operator log line indicates the workload
was never re-stamped.

```
ERROR unable to reconcile deployment with [name=<workload>]. Will try next requeue
{"error": "failed to update deployment annotation: Deployment.apps \"<workload>\" is invalid:
[metadata.annotations: Invalid value:
\"secrets.infisical.com/managed-secret.<a-52-byte-secret-name>\":
name part must be no more than 63 bytes,
spec.template.annotations: Invalid value: ... ]"}
```

Reproducible directly against the API with the key the operator would write:

```console
$ kubectl patch deploy my-app --type=merge \
    -p '{"metadata":{"annotations":{"secrets.infisical.com/managed-secret.<52-byte-name>":"v1"}}}'
The Deployment "my-app" is invalid: metadata.annotations: Invalid value: ...
name part must be no more than 63 bytes
```

### Affects both CRD generations

Reproduced on `v0.11.4`. Present in v1alpha1 and v1beta1, so migrating between them does not
help:

- `internal/controllerhelpers/controllerhelpers.go:21` (used at lines 194, 219, 244)
- `internal/services/infisicalstaticsecret/reconciler.go:36` (used at line 576)

Neither path validates or truncates the resulting key.

### Scale

On one of our clusters this affects **329 managed secrets** across ~19 services and 17
namespaces, producing roughly 400 of these errors every 15 minutes. A further 192 secrets are
within 5 bytes of the limit, so they break as soon as a name grows slightly (a longer namespace
or release-name component).

Names of the shape `<service>-<environment>-common-aws-secrets` hit this easily — the
`-common-aws-secrets` suffix alone is 19 of the 48 available bytes.

## Fix

Add `util.BuildManagedSecretAnnotationKey(keyPrefix, secretName)`:

- Only the portion after `/` is measured, since the DNS subdomain does not count toward the
  63 byte limit.
- Names that already fit are returned **unchanged**, so existing workloads keep their current
  annotation and there is no churn on upgrade.
- Longer names are truncated and suffixed with the first 8 hex characters of
  `sha256(secretName)`, keeping the key unique, stable across reconciles, and still
  recognizable.

Applied to the three v1alpha1 call sites and the v1beta1 static secret reconciler.

Example output:

```
in  (22)  my-app-staging-secrets
out       secrets.infisical.com/managed-secret.my-app-staging-secrets
          name part 37, unchanged

in  (52)  some-service-with-a-fairly-long-name-staging-secrets
out       secrets.infisical.com/managed-secret.some-service-with-a-fairly-long-name-st-c926f968
          name part 63, truncated + digest

in  (59)  another-service-with-a-long-name-staging-common-aws-secrets
out       secrets.infisical.com/managed-secret.another-service-with-a-long-name-stagin-d0a013a7
          name part 63, truncated + digest
```

## Migration considerations

- Secrets whose names already fit keep the exact same key, so existing workloads are untouched
  and no redeploy is triggered by upgrading.
- Secrets currently over the limit have no annotation at all today, because the write always
  failed, so there is no stale key to clean up.

## Testing

- New table-driven tests in `internal/util/annotations_test.go` covering: names left unchanged,
  the exact 63 byte boundary, names one byte over, real-world long names, maximum-length
  resource names, stability across repeated calls, collision-resistance for names sharing a
  truncated prefix, and the degenerate case where the prefix alone leaves no room.
- `go build ./...`, `go vet ./internal/...`, `gofmt` and `go test ./internal/util/...` all pass.
- Verified end to end against a live cluster: the current key is rejected by the API server and
  the generated key is accepted on the same Deployment.

Happy to adjust the truncation strategy (hash length, preserving the name's tail instead of its
head, or a different prefix) if you would prefer something else.
