### PR TITLE
fix(controller): reconcile InfisicalSecret annotation changes

### DIFF
--- a/internal/controller/infisicalsecret_controller.go
+++ b/internal/controller/infisicalsecret_controller.go
@@ -32,6 +32,7 @@ import (
 	defaultErrors "errors"
 
 	infisicalsecret "github.com/Infisical/infisical/k8-operator/internal/services/infisicalsecret"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -257,7 +258,7 @@ func (r *InfisicalSecretReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		).
 		For(&secretsv1alpha1.InfisicalSecret{}, builder.WithPredicates(predicate.Funcs{
 			UpdateFunc: func(e event.UpdateEvent) bool {
-				if e.ObjectOld.GetGeneration() == e.ObjectNew.GetGeneration() {
+				if !shouldReconcileInfisicalSecretUpdate(e) {
 					return false // Skip reconciliation for status-only changes
 				}
 
@@ -288,4 +289,9 @@ func (r *InfisicalSecretReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			},
 		})).Complete(r)
 
+}
+
+func shouldReconcileInfisicalSecretUpdate(e event.UpdateEvent) bool {
+	return e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration() ||
+		!equality.Semantic.DeepEqual(e.ObjectOld.GetAnnotations(), e.ObjectNew.GetAnnotations())
 }

--- a/internal/controller/infisicalsecret_controller_test.go
+++ b/internal/controller/infisicalsecret_controller_test.go
@@ -1,0 +1,86 @@
+/*
+MIT License
+
+Copyright (c) 2024 Infisical
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	secretsv1alpha1 "github.com/Infisical/infisical/k8-operator/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+)
+
+func TestShouldReconcileInfisicalSecretUpdate(t *testing.T) {
+	tests := []struct {
+		name string
+		old  metav1.ObjectMeta
+		new  metav1.ObjectMeta
+		want bool
+	}{
+		{
+			name: "generation change",
+			old:  metav1.ObjectMeta{Generation: 1},
+			new:  metav1.ObjectMeta{Generation: 2},
+			want: true,
+		},
+		{
+			name: "force sync annotation change",
+			old: metav1.ObjectMeta{
+				Generation:  1,
+				Annotations: map[string]string{"infisical.com/force-sync": "1"},
+			},
+			new: metav1.ObjectMeta{
+				Generation:  1,
+				Annotations: map[string]string{"infisical.com/force-sync": "2"},
+			},
+			want: true,
+		},
+		{
+			name: "status only update",
+			old: metav1.ObjectMeta{
+				Generation:  1,
+				Annotations: map[string]string{"infisical.com/force-sync": "1"},
+			},
+			new: metav1.ObjectMeta{
+				Generation:  1,
+				Annotations: map[string]string{"infisical.com/force-sync": "1"},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			update := event.UpdateEvent{
+				ObjectOld: &secretsv1alpha1.InfisicalSecret{ObjectMeta: tt.old},
+				ObjectNew: &secretsv1alpha1.InfisicalSecret{ObjectMeta: tt.new},
+			}
+
+			if got := shouldReconcileInfisicalSecretUpdate(update); got != tt.want {
+				t.Fatalf("shouldReconcileInfisicalSecretUpdate() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- reconcile legacy `InfisicalSecret` resources when annotations change
- retain status-only update filtering and existing stream/cache cleanup
- add regression coverage for force-sync annotation updates

## Testing
- `go test ./internal/controller -run '^TestShouldReconcileInfisicalSecretUpdate$' -count=1`
- all non-E2E packages on Linux with envtest 1.33 (`go test -p 1 -count=1`)
- `go vet ./...`
- `golangci-lint run --new-from-rev=HEAD` (0 issues)

Fixes #83