### PR TITLE
fix: prevent long secret names from breaking managed-secret annotation

### DIFF
--- a/helm-charts/secrets-operator/Chart.yaml
+++ b/helm-charts/secrets-operator/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v0.11.5
+version: v0.11.6
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.11.5"
+appVersion: "v0.11.6"

--- a/helm-charts/secrets-operator/values.yaml
+++ b/helm-charts/secrets-operator/values.yaml
@@ -31,7 +31,7 @@ controllerManager:
       readOnlyRootFilesystem: true
     image:
       repository: infisical/kubernetes-operator
-      tag: v0.11.5
+      tag: v0.11.6
     resources:
       limits:
         cpu: 500m

--- a/internal/services/infisicalstaticsecret/reconciler.go
+++ b/internal/services/infisicalstaticsecret/reconciler.go
@@ -33,7 +33,6 @@ import (
 
 const (
 	AutoReloadAnnotation       = "secrets.infisical.com/auto-reload"
-	ManagedSecretAnnotationFmt = "secrets.infisical.com/managed-secret.%s"
 )
 
 var systemAnnotationPrefixes = []string{"kubectl.kubernetes.io/", "kubernetes.io/", "k8s.io/", "helm.sh/"}
@@ -573,7 +572,7 @@ func (r *InfisicalStaticSecretReconciler) SyncKubeConfigMap(ctx context.Context,
 }
 
 func (r *InfisicalStaticSecretReconciler) PropagateSecretToWorkloads(ctx context.Context, target v1beta1.SecretTarget, etag string) (int, error) {
-	annotationKey := util.ComputeManagedSecretAnnotation(ManagedSecretAnnotationFmt, target.Name)
+	annotationKey := util.ComputeManagedSecretAnnotation(target.Name)
 
 	workloads, err := r.listWorkloadsConsumingTarget(ctx, target)
 	if err != nil {

--- a/internal/services/infisicalstaticsecret/reconciler.go
+++ b/internal/services/infisicalstaticsecret/reconciler.go
@@ -573,7 +573,7 @@ func (r *InfisicalStaticSecretReconciler) SyncKubeConfigMap(ctx context.Context,
 }
 
 func (r *InfisicalStaticSecretReconciler) PropagateSecretToWorkloads(ctx context.Context, target v1beta1.SecretTarget, etag string) (int, error) {
-	annotationKey := fmt.Sprintf(ManagedSecretAnnotationFmt, target.Name)
+	annotationKey := util.ComputeManagedSecretAnnotation(ManagedSecretAnnotationFmt, target.Name)
 
 	workloads, err := r.listWorkloadsConsumingTarget(ctx, target)
 	if err != nil {

--- a/internal/services/infisicalstaticsecret/reconciler_test.go
+++ b/internal/services/infisicalstaticsecret/reconciler_test.go
@@ -1151,7 +1151,7 @@ var _ = Describe("PropagateSecretToWorkloads", func() {
 	const namespace = "default"
 	const secretName = "app-secret"
 	const etag = "v2-etag"
-	annotationKey := util.ComputeManagedSecretAnnotation(svc.ManagedSecretAnnotationFmt, secretName)
+	annotationKey := util.ComputeManagedSecretAnnotation(secretName)
 
 	target := v1beta1.SecretTarget{
 		Name:      secretName,
@@ -1449,7 +1449,7 @@ var _ = Describe("PropagateSecretToWorkloads", func() {
 
 	Context("with a ConfigMap target", func() {
 		const configMapName = "app-config"
-		configMapAnnotationKey := util.ComputeManagedSecretAnnotation(svc.ManagedSecretAnnotationFmt, configMapName)
+		configMapAnnotationKey := util.ComputeManagedSecretAnnotation(configMapName)
 
 		configMapTarget := v1beta1.SecretTarget{
 			Name:      configMapName,

--- a/internal/services/infisicalstaticsecret/reconciler_test.go
+++ b/internal/services/infisicalstaticsecret/reconciler_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Infisical/infisical/k8-operator/internal/crypto"
 	svc "github.com/Infisical/infisical/k8-operator/internal/services/infisicalstaticsecret"
 	templatev1 "github.com/Infisical/infisical/k8-operator/internal/template/v1"
+	"github.com/Infisical/infisical/k8-operator/internal/util"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8Errors "k8s.io/apimachinery/pkg/api/errors"
@@ -1150,7 +1151,7 @@ var _ = Describe("PropagateSecretToWorkloads", func() {
 	const namespace = "default"
 	const secretName = "app-secret"
 	const etag = "v2-etag"
-	annotationKey := fmt.Sprintf(svc.ManagedSecretAnnotationFmt, secretName)
+	annotationKey := util.ComputeManagedSecretAnnotation(svc.ManagedSecretAnnotationFmt, secretName)
 
 	target := v1beta1.SecretTarget{
 		Name:      secretName,
@@ -1448,7 +1449,7 @@ var _ = Describe("PropagateSecretToWorkloads", func() {
 
 	Context("with a ConfigMap target", func() {
 		const configMapName = "app-config"
-		configMapAnnotationKey := fmt.Sprintf(svc.ManagedSecretAnnotationFmt, configMapName)
+		configMapAnnotationKey := util.ComputeManagedSecretAnnotation(svc.ManagedSecretAnnotationFmt, configMapName)
 
 		configMapTarget := v1beta1.SecretTarget{
 			Name:      configMapName,

--- a/internal/util/handler.go
+++ b/internal/util/handler.go
@@ -61,7 +61,7 @@ func (e *EnqueueDelayedEventHandler) Generic(_ context.Context, evt event.TypedG
 	}
 }
 
-func ComputeManagedSecretAnnotation(template, secretName string) string {
+func ComputeManagedSecretAnnotation(secretName string) string {
 	sum := sha256.Sum256([]byte(secretName))
-	return fmt.Sprintf(template, hex.EncodeToString(sum[:16]))
+	return fmt.Sprintf(ManagedSecretAnnotationFmt, hex.EncodeToString(sum[:16]))
 }

--- a/internal/util/handler.go
+++ b/internal/util/handler.go
@@ -2,6 +2,9 @@ package util
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
 	"math/rand"
 	"time"
 
@@ -56,4 +59,9 @@ func (e *EnqueueDelayedEventHandler) Generic(_ context.Context, evt event.TypedG
 	} else {
 		q.Add(req)
 	}
+}
+
+func ComputeManagedSecretAnnotation(template, secretName string) string {
+	sum := sha256.Sum256([]byte(secretName))
+	return fmt.Sprintf(template, hex.EncodeToString(sum[:16]))
 }

--- a/internal/util/helpers_test.go
+++ b/internal/util/helpers_test.go
@@ -1,6 +1,8 @@
 package util_test
 
 import (
+	"strings"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -53,6 +55,36 @@ var _ = Describe("AppendAPIEndpoint", func() {
 			name:   "ends with /api/",
 			input:  "https://app.infisical.com/api/",
 			output: "https://app.infisical.com/api",
+		}),
+	)
+})
+
+var _ = Describe("ComputeManagedSecretAnnotation", func() {
+
+	const template = "secrets.infisical.com/managed-secret.%s"
+
+	type TestCase struct {
+		name       string
+		secretName string
+	}
+
+	DescribeTable("never surpasses 63 characters",
+		func(tc TestCase) {
+			annotation := util.ComputeManagedSecretAnnotation(template, tc.secretName)
+			annotationName := strings.Split(annotation, "/")[1]
+			Expect(len(annotationName)).To(BeNumerically("<", 64))
+		},
+		Entry("input is less than 63 characters long", TestCase{
+			name:       "input is less than 63 characters long",
+			secretName: "short-name",
+		}),
+		Entry("input is 63 characters long", TestCase{
+			name:       "input is 63 characters long",
+			secretName: "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKL",
+		}),
+		Entry("input is longer than 63 characters", TestCase{
+			name:       "input is longer than 63 characters",
+			secretName: "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKL_LONG_STRING",
 		}),
 	)
 })

--- a/internal/util/helpers_test.go
+++ b/internal/util/helpers_test.go
@@ -61,8 +61,6 @@ var _ = Describe("AppendAPIEndpoint", func() {
 
 var _ = Describe("ComputeManagedSecretAnnotation", func() {
 
-	const template = "secrets.infisical.com/managed-secret.%s"
-
 	type TestCase struct {
 		name       string
 		secretName string
@@ -70,7 +68,7 @@ var _ = Describe("ComputeManagedSecretAnnotation", func() {
 
 	DescribeTable("never surpasses 63 characters",
 		func(tc TestCase) {
-			annotation := util.ComputeManagedSecretAnnotation(template, tc.secretName)
+			annotation := util.ComputeManagedSecretAnnotation(tc.secretName)
 			annotationName := strings.Split(annotation, "/")[1]
 			Expect(len(annotationName)).To(BeNumerically("<", 64))
 		},

--- a/internal/util/kubernetes.go
+++ b/internal/util/kubernetes.go
@@ -18,6 +18,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const ManagedSecretAnnotationFmt = "secrets.infisical.com/managed-secret.%s"
+
 const INFISICAL_MACHINE_IDENTITY_CLIENT_ID = "clientId"
 const INFISICAL_MACHINE_IDENTITY_CLIENT_SECRET = "clientSecret"
 

--- a/test/e2e/e2e_staticsecret_test.go
+++ b/test/e2e/e2e_staticsecret_test.go
@@ -16,7 +16,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	secretsv1beta1 "github.com/Infisical/infisical/k8-operator/api/v1beta1"
+	"github.com/Infisical/infisical/k8-operator/internal/services/infisicalstaticsecret"
 	"github.com/Infisical/infisical/k8-operator/internal/testutil/infra"
+	"github.com/Infisical/infisical/k8-operator/internal/util"
 )
 
 const testNamespace = "default"
@@ -616,7 +618,7 @@ var _ = Describe("InfisicalStaticSecret", Ordered, ContinueOnFailure, func() {
 		synced := expectSecret(secretName, "e2e-superlong-secret-name-sync")
 		expectSecretData(synced, map[string]string{"SHARED_KEY": "shared-val"})
 
-		annotationKey := fmt.Sprintf("secrets.infisical.com/managed-secret.%s", secretName)
+		annotationKey := util.ComputeManagedSecretAnnotation(infisicalstaticsecret.ManagedSecretAnnotationFmt, secretName)
 		Eventually(func(g Gomega) {
 			var updated appsv1.Deployment
 			g.Expect(k.Get(ctx, types.NamespacedName{Name: "e2e-superlong-consumer", Namespace: testNamespace}, &updated)).To(Succeed())

--- a/test/e2e/e2e_staticsecret_test.go
+++ b/test/e2e/e2e_staticsecret_test.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -562,6 +563,37 @@ var _ = Describe("InfisicalStaticSecret", Ordered, ContinueOnFailure, func() {
 
 		const secretName = "e2e-mt-secret-with-a-super-long-name-that-would-cause-k8s-to-reject-annotation"
 
+		replicas := int32(1)
+		dep := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "e2e-superlong-consumer",
+				Namespace: testNamespace,
+				Annotations: map[string]string{
+					"secrets.infisical.com/auto-reload": "true",
+				},
+			},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: &replicas,
+				Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "e2e-superlong-consumer"}},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "e2e-superlong-consumer"}},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{
+							Name:  "main",
+							Image: "busybox",
+							EnvFrom: []corev1.EnvFromSource{{
+								SecretRef: &corev1.SecretEnvSource{
+									LocalObjectReference: corev1.LocalObjectReference{Name: secretName},
+								},
+							}},
+						}},
+					},
+				},
+			},
+		}
+		Expect(k.Create(ctx, dep)).To(Succeed())
+		DeferCleanup(func() { _ = client.IgnoreNotFound(k.Delete(ctx, dep)) })
+
 		createStaticSecret("e2e-superlong-secret-name-sync", secretsv1beta1.InfisicalStaticSecretSpec{
 			InfisicalAuthRef: authRef,
 			SyncOptions:      &secretsv1beta1.SyncOptions{RefreshInterval: "1h"},
@@ -583,6 +615,13 @@ var _ = Describe("InfisicalStaticSecret", Ordered, ContinueOnFailure, func() {
 
 		synced := expectSecret(secretName, "e2e-superlong-secret-name-sync")
 		expectSecretData(synced, map[string]string{"SHARED_KEY": "shared-val"})
+
+		annotationKey := fmt.Sprintf("secrets.infisical.com/managed-secret.%s", secretName)
+		Eventually(func(g Gomega) {
+			var updated appsv1.Deployment
+			g.Expect(k.Get(ctx, types.NamespacedName{Name: "e2e-superlong-consumer", Namespace: testNamespace}, &updated)).To(Succeed())
+			g.Expect(updated.Annotations).To(HaveKey(annotationKey), "auto-reload annotation was not propagated to deployment")
+		}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Succeed())
 	})
 
 	It("should sync using project slug instead of project ID", func() {

--- a/test/e2e/e2e_staticsecret_test.go
+++ b/test/e2e/e2e_staticsecret_test.go
@@ -556,6 +556,35 @@ var _ = Describe("InfisicalStaticSecret", Ordered, ContinueOnFailure, func() {
 		Expect(cm.Data).To(HaveKeyWithValue("SHARED_KEY", "shared-val"))
 	})
 
+	It("should not break if secret name is too long", func() {
+		api.CreateFolder(GinkgoT(), project.ID, project.EnvSlug, "/", "superlong")
+		api.CreateSecret(GinkgoT(), project.ID, project.EnvSlug, "/superlong", "SHARED_KEY", "shared-val", nil)
+
+		const secretName = "e2e-mt-secret-with-a-super-long-name-that-would-cause-k8s-to-reject-annotation"
+
+		createStaticSecret("e2e-superlong-secret-name-sync", secretsv1beta1.InfisicalStaticSecretSpec{
+			InfisicalAuthRef: authRef,
+			SyncOptions:      &secretsv1beta1.SyncOptions{RefreshInterval: "1h"},
+			Sources: []secretsv1beta1.SecretSource{{
+				ProjectId:       project.ID,
+				EnvironmentSlug: project.EnvSlug,
+				SecretPath:      "/superlong",
+			}},
+			Targets: []secretsv1beta1.SecretTarget{
+				{
+					Name:           secretName,
+					Namespace:      testNamespace,
+					Kind:           secretsv1beta1.SecretTargetKindSecret,
+					SecretType:     corev1.SecretTypeOpaque,
+					CreationPolicy: secretsv1beta1.CreationPolicyOwner,
+				},
+			},
+		})
+
+		synced := expectSecret("e2e-mt-secret", "e2e-superlong-secret-name-sync")
+		expectSecretData(synced, map[string]string{"SHARED_KEY": "shared-val"})
+	})
+
 	It("should sync using project slug instead of project ID", func() {
 		api.CreateFolder(GinkgoT(), project.ID, project.EnvSlug, "/", "slug-test")
 		api.CreateSecret(GinkgoT(), project.ID, project.EnvSlug, "/slug-test", "SLUG_KEY", "slug-value", nil)

--- a/test/e2e/e2e_staticsecret_test.go
+++ b/test/e2e/e2e_staticsecret_test.go
@@ -581,7 +581,7 @@ var _ = Describe("InfisicalStaticSecret", Ordered, ContinueOnFailure, func() {
 			},
 		})
 
-		synced := expectSecret("e2e-mt-secret", "e2e-superlong-secret-name-sync")
+		synced := expectSecret(secretName, "e2e-superlong-secret-name-sync")
 		expectSecretData(synced, map[string]string{"SHARED_KEY": "shared-val"})
 	})
 

--- a/test/e2e/e2e_staticsecret_test.go
+++ b/test/e2e/e2e_staticsecret_test.go
@@ -16,7 +16,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	secretsv1beta1 "github.com/Infisical/infisical/k8-operator/api/v1beta1"
-	"github.com/Infisical/infisical/k8-operator/internal/services/infisicalstaticsecret"
 	"github.com/Infisical/infisical/k8-operator/internal/testutil/infra"
 	"github.com/Infisical/infisical/k8-operator/internal/util"
 )
@@ -618,7 +617,7 @@ var _ = Describe("InfisicalStaticSecret", Ordered, ContinueOnFailure, func() {
 		synced := expectSecret(secretName, "e2e-superlong-secret-name-sync")
 		expectSecretData(synced, map[string]string{"SHARED_KEY": "shared-val"})
 
-		annotationKey := util.ComputeManagedSecretAnnotation(infisicalstaticsecret.ManagedSecretAnnotationFmt, secretName)
+		annotationKey := util.ComputeManagedSecretAnnotation(secretName)
 		Eventually(func(g Gomega) {
 			var updated appsv1.Deployment
 			g.Expect(k.Get(ctx, types.NamespacedName{Name: "e2e-superlong-consumer", Namespace: testNamespace}, &updated)).To(Succeed())


### PR DESCRIPTION
## Description

Auto-reload silently fails when the managed secret name is longer than 48 characters because the operator adds a secrets.infisical.com/managed-secret.<name> annotation whose name part exceeds Kubernetes' 63-character limit.

Example error when adding the annotation manually:
The Deployment "app" is invalid: metadata.annotations: Invalid value: "secrets.infisical.com/managed-secret.294cce783e758ef09dbf520c45b3d8bee5d7c89e-infisical-secrets": name part must be no more than 63 characters

## Solution

Hashing the secret name to ensure it never surpasses the 63 characters limit.